### PR TITLE
refactor(job): rename `FuncJob` to `JobFunc`

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -41,7 +41,7 @@ func (c Chain) Then(j Job) Job {
 // Recover panics in wrapped jobs and log them with the provided logger.
 func Recover(logger Logger) JobWrapper {
 	return func(j Job) Job {
-		return FuncJob(func(ctx context.Context) {
+		return JobFunc(func(ctx context.Context) {
 			defer func() {
 				if r := recover(); r != nil {
 					const size = 64 << 10
@@ -65,7 +65,7 @@ func Recover(logger Logger) JobWrapper {
 func DelayIfStillRunning(logger Logger) JobWrapper {
 	return func(j Job) Job {
 		var mu sync.Mutex
-		return FuncJob(func(ctx context.Context) {
+		return JobFunc(func(ctx context.Context) {
 			start := time.Now()
 			mu.Lock()
 			defer mu.Unlock()
@@ -83,7 +83,7 @@ func SkipIfStillRunning(logger Logger) JobWrapper {
 	return func(j Job) Job {
 		ch := make(chan struct{}, 1)
 		ch <- struct{}{}
-		return FuncJob(func(ctx context.Context) {
+		return JobFunc(func(ctx context.Context) {
 			select {
 			case v := <-ch:
 				defer func() { ch <- v }()

--- a/chain_test.go
+++ b/chain_test.go
@@ -12,7 +12,7 @@ import (
 
 func appendingJob(slice *[]int, value int) Job {
 	var m sync.Mutex
-	return FuncJob(func(context.Context) {
+	return JobFunc(func(context.Context) {
 		m.Lock()
 		*slice = append(*slice, value)
 		m.Unlock()
@@ -21,7 +21,7 @@ func appendingJob(slice *[]int, value int) Job {
 
 func appendingWrapper(slice *[]int, value int) JobWrapper {
 	return func(j Job) Job {
-		return FuncJob(func(ctx context.Context) {
+		return JobFunc(func(ctx context.Context) {
 			appendingJob(slice, value).Run(ctx)
 			j.Run(ctx)
 		})
@@ -43,7 +43,7 @@ func TestChain(t *testing.T) {
 }
 
 func TestChainRecover(t *testing.T) {
-	panickingJob := FuncJob(func(context.Context) {
+	panickingJob := JobFunc(func(context.Context) {
 		panic("panickingJob panics")
 	})
 

--- a/cron.go
+++ b/cron.go
@@ -32,11 +32,6 @@ type ScheduleParser interface {
 	Parse(spec string) (Schedule, error)
 }
 
-// Job is an interface for submitted cron jobs.
-type Job interface {
-	Run(ctx context.Context)
-}
-
 // Schedule describes a job's duty cycle.
 type Schedule interface {
 	// Next returns the next activation time, later than the given time.
@@ -132,16 +127,11 @@ func New(opts ...Option) *Cron {
 	return c
 }
 
-// FuncJob is a wrapper that turns a func() into a cron.Job
-type FuncJob func(ctx context.Context)
-
-func (f FuncJob) Run(ctx context.Context) { f(ctx) }
-
 // AddFunc adds a func to the Cron to be run on the given schedule.
 // The spec is parsed using the time zone of this Cron instance as the default.
 // An opaque ID is returned that can be used to later remove it.
 func (c *Cron) AddFunc(spec string, cmd func(ctx context.Context)) (EntryID, error) {
-	return c.AddJob(spec, FuncJob(cmd))
+	return c.AddJob(spec, JobFunc(cmd))
 }
 
 // AddJob adds a Job to the Cron to be run on the given schedule.

--- a/cron_test.go
+++ b/cron_test.go
@@ -272,9 +272,9 @@ func TestRunningMultipleSchedules(t *testing.T) {
 	cron.AddFunc("0 0 0 1 1 ?", func(context.Context) {})            //nolint:errcheck
 	cron.AddFunc("0 0 0 31 12 ?", func(context.Context) {})          //nolint:errcheck
 	cron.AddFunc("* * * * * ?", func(context.Context) { wg.Done() }) //nolint:errcheck
-	cron.Schedule(Every(time.Minute), FuncJob(func(context.Context) {}))
-	cron.Schedule(Every(time.Second), FuncJob(func(context.Context) { wg.Done() }))
-	cron.Schedule(Every(time.Hour), FuncJob(func(context.Context) {}))
+	cron.Schedule(Every(time.Minute), JobFunc(func(context.Context) {}))
+	cron.Schedule(Every(time.Second), JobFunc(func(context.Context) { wg.Done() }))
+	cron.Schedule(Every(time.Hour), JobFunc(func(context.Context) {}))
 
 	cron.Start()
 	defer cron.Stop()
@@ -494,8 +494,8 @@ func TestScheduleAfterRemoval(t *testing.T) {
 	var mu sync.Mutex
 
 	cron := newWithSeconds()
-	hourJob := cron.Schedule(Every(time.Hour), FuncJob(func(context.Context) {}))
-	cron.Schedule(Every(time.Second), FuncJob(func(context.Context) {
+	hourJob := cron.Schedule(Every(time.Hour), JobFunc(func(context.Context) {}))
+	cron.Schedule(Every(time.Second), JobFunc(func(context.Context) {
 		mu.Lock()
 		defer mu.Unlock()
 		switch calls {
@@ -539,7 +539,7 @@ func TestJobWithZeroTimeDoesNotRun(t *testing.T) {
 	cron := newWithSeconds()
 	var calls int64
 	cron.AddFunc("* * * * * *", func(context.Context) { atomic.AddInt64(&calls, 1) }) //nolint:errcheck
-	cron.Schedule(new(ZeroSchedule), FuncJob(func(context.Context) { t.Error("expected zero task will not run") }))
+	cron.Schedule(new(ZeroSchedule), JobFunc(func(context.Context) { t.Error("expected zero task will not run") }))
 	cron.Start()
 	defer cron.Stop()
 	<-time.After(OneSecond)

--- a/job.go
+++ b/job.go
@@ -1,0 +1,13 @@
+package cron
+
+import "context"
+
+// Job is an interface for submitted cron jobs.
+type Job interface {
+	Run(ctx context.Context)
+}
+
+// JobFunc is a wrapper that turns a func(context.Context) into a cron.Job
+type JobFunc func(ctx context.Context)
+
+func (j JobFunc) Run(ctx context.Context) { j(ctx) }


### PR DESCRIPTION
reference `http.HandlerFunc` https://github.com/golang/go/blob/889abb17e125bb0f5d8de61bb80ef15fbe2a130d/src/net/http/server.go#L2216