### PR TITLE
feat(entry): add `Entry` info in `ctx`

### DIFF
--- a/cron_test.go
+++ b/cron_test.go
@@ -465,10 +465,10 @@ func TestJob(t *testing.T) {
 	job5 := cron.Schedule(Every(5*time.Minute), testJob{wg, "job5"})
 
 	// Test getting an Entry pre-Start.
-	if actualName := cron.Entry(job2).Job.(testJob).name; actualName != "job2" {
+	if actualName := cron.Entry(job2).job.(testJob).name; actualName != "job2" {
 		t.Error("wrong job retrieved:", actualName)
 	}
-	if actualName := cron.Entry(job5).Job.(testJob).name; actualName != "job5" {
+	if actualName := cron.Entry(job5).job.(testJob).name; actualName != "job5" {
 		t.Error("wrong job retrieved:", actualName)
 	}
 
@@ -486,7 +486,7 @@ func TestJob(t *testing.T) {
 
 	var actuals []string // nolint:prealloc
 	for _, entry := range cron.Entries() {
-		actuals = append(actuals, entry.Job.(testJob).name)
+		actuals = append(actuals, entry.job.(testJob).name)
 	}
 
 	for i, expected := range expecteds {
@@ -496,10 +496,10 @@ func TestJob(t *testing.T) {
 	}
 
 	// Test getting Entries.
-	if actualName := cron.Entry(job2).Job.(testJob).name; actualName != "job2" {
+	if actualName := cron.Entry(job2).job.(testJob).name; actualName != "job2" {
 		t.Error("wrong job retrieved:", actualName)
 	}
-	if actualName := cron.Entry(job5).Job.(testJob).name; actualName != "job5" {
+	if actualName := cron.Entry(job5).job.(testJob).name; actualName != "job5" {
 		t.Error("wrong job retrieved:", actualName)
 	}
 }

--- a/entry.go
+++ b/entry.go
@@ -1,0 +1,93 @@
+package cron
+
+import (
+	"context"
+	"time"
+)
+
+// EntryID identifies an entry within a Cron instance
+type EntryID int
+
+// Entry consists of a schedule and the func to execute on that schedule.
+type Entry struct {
+	// ID is the cron-assigned ID of this entry, which may be used to look up a
+	// snapshot or remove it.
+	ID EntryID
+
+	// Schedule on which this job should be run.
+	Schedule Schedule
+
+	// Next time the job will run, or the zero time if Cron has not been
+	// started or this entry's schedule is unsatisfiable
+	Next time.Time
+
+	// Prev is the last time this job was run, or the zero time if never.
+	Prev time.Time
+
+	// wrappedJob is the thing to run when the Schedule is activated.
+	wrappedJob Job
+
+	// job is the thing that was submitted to cron.
+	// It is kept around so that user code that needs to get at the job later,
+	// e.g. via Entries() can do so.
+	job Job
+
+	// middlewares are the list of middlewares to apply to the job.
+	middlewares []Middleware
+}
+
+type EntryOption func(*Entry)
+
+func WithEntryMiddlewares(middlewares ...Middleware) EntryOption {
+	return func(e *Entry) {
+		e.middlewares = middlewares
+	}
+}
+
+// newEntry creates a new entry with the given schedule and job.
+func newEntry(id EntryID, schedule Schedule, job Job, opts ...EntryOption) *Entry {
+	entry := &Entry{
+		ID:       id,
+		Schedule: schedule,
+		job:      job,
+	}
+	for _, opt := range opts {
+		opt(entry)
+	}
+
+	// Wrap the job with the entry context.
+	middlewares := append([]Middleware{
+		func(job Job) Job {
+			return JobFunc(func(ctx context.Context) error {
+				return job.Run(WithEntryContext(ctx, entry))
+			})
+		},
+	}, entry.middlewares...)
+
+	// Wrap the job with the middlewares.
+	entry.wrappedJob = Chain(middlewares...)(entry.job)
+
+	return entry
+}
+
+func (e *Entry) WrappedJob() Job {
+	return e.wrappedJob
+}
+
+// Valid returns true if this is not the zero entry.
+func (e *Entry) Valid() bool { return e.ID != 0 }
+
+// ------------------------------------ Entry Context ------------------------------------
+
+type entryContextKey struct{}
+
+// WithEntryContext returns a new context with the given EntryID.
+func WithEntryContext(ctx context.Context, entry *Entry) context.Context {
+	return context.WithValue(ctx, entryContextKey{}, entry)
+}
+
+// EntryFromContext returns the EntryID from the context.
+func EntryFromContext(ctx context.Context) (*Entry, bool) {
+	entry, ok := ctx.Value(entryContextKey{}).(*Entry)
+	return entry, ok
+}

--- a/entry_test.go
+++ b/entry_test.go
@@ -8,13 +8,33 @@ import (
 )
 
 func TestEntry_Context(t *testing.T) {
-	entry := newEntry(1, nil, JobFunc(func(ctx context.Context) error {
-		entry, ok := EntryFromContext(ctx)
-		assert.True(t, ok)
-		assert.Equal(t, entry.ID, EntryID(1))
+	tests := []struct {
+		name string
+		id   EntryID
+	}{
+		{"", 1},
+		{"", 2},
+	}
 
-		return nil
-	}))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
 
-	assert.NoError(t, entry.WrappedJob().Run(context.Background()))
+			// non-existent entry
+			entry, ok := EntryFromContext(ctx)
+			assert.False(t, ok)
+			assert.Nil(t, entry)
+
+			// existent entry
+			entry = newEntry(tt.id, nil, JobFunc(func(ctx context.Context) error {
+				entry, ok := EntryFromContext(ctx)
+				assert.True(t, ok)
+				assert.Equal(t, entry.ID, tt.id)
+
+				return nil
+			}))
+
+			assert.NoError(t, entry.WrappedJob().Run(ctx))
+		})
+	}
 }

--- a/entry_test.go
+++ b/entry_test.go
@@ -2,6 +2,7 @@ package cron
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -42,12 +43,12 @@ func TestEntry_Context(t *testing.T) {
 
 func TestEntry_ContextUseCron(t *testing.T) {
 	cron := newWithSeconds()
-	var e1, e2 *Entry
+	var e1, e2 atomic.Value
 	_, err := cron.AddFunc("* * * * *", func(ctx context.Context) error {
 		entry, ok := EntryFromContext(ctx)
 		assert.True(t, ok)
 		assert.True(t, entry.Valid())
-		e1 = entry
+		e1.Store(entry)
 
 		t.Logf("entry id: %d", entry.ID)
 
@@ -59,7 +60,7 @@ func TestEntry_ContextUseCron(t *testing.T) {
 		entry, ok := EntryFromContext(ctx)
 		assert.True(t, ok)
 		assert.True(t, entry.Valid())
-		e2 = entry
+		e2.Store(entry)
 
 		t.Logf("entry id: %d", entry.ID)
 
@@ -74,5 +75,5 @@ func TestEntry_ContextUseCron(t *testing.T) {
 	time.Sleep(time.Second)
 
 	// ensure the entries are different
-	assert.NotEqual(t, e1.ID, e2.ID)
+	assert.NotEqual(t, e1.Load().(*Entry).ID, e2.Load().(*Entry).ID)
 }

--- a/entry_test.go
+++ b/entry_test.go
@@ -3,6 +3,7 @@ package cron
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -37,4 +38,41 @@ func TestEntry_Context(t *testing.T) {
 			assert.NoError(t, entry.WrappedJob().Run(ctx))
 		})
 	}
+}
+
+func TestEntry_ContextUseCron(t *testing.T) {
+	cron := newWithSeconds()
+	var e1, e2 *Entry
+	_, err := cron.AddFunc("* * * * *", func(ctx context.Context) error {
+		entry, ok := EntryFromContext(ctx)
+		assert.True(t, ok)
+		assert.True(t, entry.Valid())
+		e1 = entry
+
+		t.Logf("entry id: %d", entry.ID)
+
+		return nil
+	})
+	assert.NoError(t, err)
+
+	_, err = cron.AddFunc("* * * * *", func(ctx context.Context) error {
+		entry, ok := EntryFromContext(ctx)
+		assert.True(t, ok)
+		assert.True(t, entry.Valid())
+		e2 = entry
+
+		t.Logf("entry id: %d", entry.ID)
+
+		return nil
+	})
+	assert.NoError(t, err)
+
+	cron.Start()
+	defer cron.Stop()
+
+	// wait for the job to run
+	time.Sleep(time.Second)
+
+	// ensure the entries are different
+	assert.NotEqual(t, e1.ID, e2.ID)
 }

--- a/entry_test.go
+++ b/entry_test.go
@@ -1,0 +1,20 @@
+package cron
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEntry_Context(t *testing.T) {
+	entry := newEntry(1, nil, JobFunc(func(ctx context.Context) error {
+		entry, ok := EntryFromContext(ctx)
+		assert.True(t, ok)
+		assert.Equal(t, entry.ID, EntryID(1))
+
+		return nil
+	}))
+
+	assert.NoError(t, entry.WrappedJob().Run(context.Background()))
+}


### PR DESCRIPTION
closed: https://github.com/flc1125/go-cron/issues/21

example:

```go
package main

import (
	"context"
	"fmt"
	"log"
	"time"

	"github.com/flc1125/go-cron/v4"
)

func main() {
	c := cron.New(
		cron.WithSeconds(),
	)

	_, _ = c.AddFunc("* * * * * *", func(ctx context.Context) error {
		entry, ok := cron.EntryFromContext(ctx)
		if ok {
			log.Println(fmt.Sprintf("entry id: %d", entry.ID))
		}
		return nil
	})

	c.Start()
	defer c.Stop()

	time.Sleep(5 * time.Second)
}
```

output:

```shell
2024/10/27 21:27:45 entry id: 1
2024/10/27 21:27:46 entry id: 1
2024/10/27 21:27:47 entry id: 1
2024/10/27 21:27:48 entry id: 1
2024/10/27 21:27:49 entry id: 1
...
```