### PR TITLE
refactor(middleware): refactor `SkipIfStillRunning` to `nooverlapping.New()`

### DIFF
--- a/internal/logger/buffer.go
+++ b/internal/logger/buffer.go
@@ -29,6 +29,12 @@ func (b *Buffer) String() string {
 	return b.buf.String()
 }
 
+func (b *Buffer) Reset() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.buf.Reset()
+}
+
 func NewBufferLogger(buffer *Buffer) cron.Logger {
 	return cron.VerbosePrintfLogger(log.New(buffer, "", log.LstdFlags))
 }

--- a/internal/logger/buffer.go
+++ b/internal/logger/buffer.go
@@ -30,5 +30,5 @@ func (b *Buffer) String() string {
 }
 
 func NewBufferLogger(buffer *Buffer) cron.Logger {
-	return cron.PrintfLogger(log.New(buffer, "", log.LstdFlags))
+	return cron.VerbosePrintfLogger(log.New(buffer, "", log.LstdFlags))
 }

--- a/middleware/nooverlapping/nooverlapping.go
+++ b/middleware/nooverlapping/nooverlapping.go
@@ -1,0 +1,50 @@
+package nooverlapping
+
+import (
+	"context"
+
+	"github.com/flc1125/go-cron/v4"
+)
+
+type options struct {
+	logger cron.Logger
+}
+
+type Option func(*options)
+
+func WithLogger(logger cron.Logger) Option {
+	return func(o *options) {
+		o.logger = logger
+	}
+}
+
+func newOptions(opts ...Option) options {
+	opt := options{
+		logger: cron.DefaultLogger,
+	}
+	for _, o := range opts {
+		o(&opt)
+	}
+	return opt
+}
+
+// New returns a without Overlapping middleware.
+// if the job is running, skip the job.
+// Based on the old version of SkipIfStillRunning
+func New(opts ...Option) cron.Middleware {
+	o := newOptions(opts...)
+	return func(job cron.Job) cron.Job {
+		ch := make(chan struct{}, 1)
+		ch <- struct{}{}
+		return cron.JobFunc(func(ctx context.Context) error {
+			select {
+			case v := <-ch:
+				defer func() { ch <- v }()
+				return job.Run(ctx)
+			default:
+				o.logger.Info("job is still running, skip")
+				return nil
+			}
+		})
+	}
+}

--- a/middleware/nooverlapping/nooverlapping_test.go
+++ b/middleware/nooverlapping/nooverlapping_test.go
@@ -12,15 +12,20 @@ import (
 	"github.com/flc1125/go-cron/v4/internal/logger"
 )
 
-var ctx = context.Background()
+var (
+	ctx           = context.Background()
+	buf           = logger.NewBuffer()
+	noOverlapping = New(WithLogger(logger.NewBufferLogger(buf)))
+	wg            = sync.WaitGroup{}
+)
 
 func TestNoOverlapping(t *testing.T) {
+	buf.Reset()
+
 	var (
-		buf = logger.NewBuffer()
-		m   = New(WithLogger(logger.NewBufferLogger(buf)))
 		ch  = make(chan struct{}, 100)
 		wg  = sync.WaitGroup{}
-		job = m(cron.JobFunc(func(context.Context) error {
+		job = noOverlapping(cron.JobFunc(func(context.Context) error {
 			ch <- struct{}{}
 			time.Sleep(2 * time.Millisecond)
 			return nil
@@ -36,93 +41,143 @@ func TestNoOverlapping(t *testing.T) {
 	}
 	wg.Wait()
 
-	assert.Len(t, ch, 1)
+	assert.True(t, len(ch) < 100)
 	assert.Contains(t, buf.String(), "job is still running, skip")
 }
 
-// func TestChainSkipIfStillRunning(t *testing.T) {
-// 	t.Run("runs immediately", func(t *testing.T) {
-// 		var j countJob
-// 		wrappedJob := Chain(SkipIfStillRunning(DiscardLogger))(&j)
-// 		go wrappedJob.Run(context.Background()) //nolint:errcheck
-// 		time.Sleep(20 * time.Millisecond)       // Give the job 2ms to complete.
-// 		if c := j.Done(); c != 1 {
-// 			t.Errorf("expected job run once, immediately, got %d", c)
-// 		}
-// 	})
-//
-// 	t.Run("second run immediate if first done", func(t *testing.T) {
-// 		var j countJob
-// 		wrappedJob := Chain(SkipIfStillRunning(DiscardLogger))(&j)
-// 		go func() {
-// 			go wrappedJob.Run(context.Background()) //nolint:errcheck
-// 			time.Sleep(10 * time.Millisecond)
-// 			go wrappedJob.Run(context.Background()) //nolint:errcheck
-// 		}()
-// 		time.Sleep(30 * time.Millisecond) // Give both jobs 3ms to complete.
-// 		if c := j.Done(); c != 2 {
-// 			t.Errorf("expected job run twice, immediately, got %d", c)
-// 		}
-// 	})
-//
-// 	t.Run("second run skipped if first not done", func(t *testing.T) {
-// 		var j countJob
-// 		j.delay = 10 * time.Millisecond
-// 		wrappedJob := Chain(SkipIfStillRunning(DiscardLogger))(&j)
-// 		go func() {
-// 			go wrappedJob.Run(context.Background()) //nolint:errcheck
-// 			time.Sleep(time.Millisecond)
-// 			go wrappedJob.Run(context.Background()) //nolint:errcheck
-// 		}()
-//
-// 		// After 5ms, the first job is still in progress, and the second job was
-// 		// aleady skipped.
-// 		time.Sleep(5 * time.Millisecond)
-// 		started, done := j.Started(), j.Done()
-// 		if started != 1 || done != 0 {
-// 			t.Error("expected first job started, but not finished, got", started, done)
-// 		}
-//
-// 		// Verify that the first job completes and second does not run.
-// 		time.Sleep(25 * time.Millisecond)
-// 		started, done = j.Started(), j.Done()
-// 		if started != 1 || done != 1 {
-// 			t.Error("expected second job skipped, got", started, done)
-// 		}
-// 	})
-//
-// 	t.Run("skip 10 jobs on rapid fire", func(t *testing.T) {
-// 		var j countJob
-// 		j.delay = 10 * time.Millisecond
-// 		wrappedJob := Chain(SkipIfStillRunning(DiscardLogger))(&j)
-// 		for i := 0; i < 11; i++ {
-// 			go wrappedJob.Run(context.Background()) //nolint:errcheck
-// 		}
-// 		time.Sleep(200 * time.Millisecond)
-// 		done := j.Done()
-// 		if done != 1 {
-// 			t.Error("expected 1 jobs executed, 10 jobs dropped, got", done)
-// 		}
-// 	})
-//
-// 	t.Run("different jobs independent", func(t *testing.T) {
-// 		var j1, j2 countJob
-// 		j1.delay = 10 * time.Millisecond
-// 		j2.delay = 10 * time.Millisecond
-// 		chain := Chain(SkipIfStillRunning(DiscardLogger))
-// 		wrappedJob1 := chain(&j1)
-// 		wrappedJob2 := chain(&j2)
-// 		for i := 0; i < 11; i++ {
-// 			go wrappedJob1.Run(context.Background()) //nolint:errcheck
-// 			go wrappedJob2.Run(context.Background()) //nolint:errcheck
-// 		}
-// 		time.Sleep(100 * time.Millisecond)
-// 		var (
-// 			done1 = j1.Done()
-// 			done2 = j2.Done()
-// 		)
-// 		if done1 != 1 || done2 != 1 {
-// 			t.Error("expected both jobs executed once, got", done1, "and", done2)
-// 		}
-// 	})
-// }
+func TestNoOverlapping_Chain(t *testing.T) {
+	buf.Reset()
+
+	var (
+		ch  = make(chan struct{}, 100)
+		job = cron.Chain(noOverlapping)(cron.JobFunc(func(context.Context) error {
+			ch <- struct{}{}
+			time.Sleep(2 * time.Millisecond)
+			return nil
+		}))
+	)
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			assert.NoError(t, job.Run(ctx))
+		}()
+	}
+	wg.Wait()
+
+	assert.True(t, len(ch) < 100)
+	assert.Contains(t, buf.String(), "job is still running, skip")
+}
+
+func TestNoOverlapping_Cases(t *testing.T) {
+	t.Run("second run immediate if first done", func(t *testing.T) {
+		buf.Reset()
+		ch := make(chan struct{}, 10)
+		job := noOverlapping(cron.JobFunc(func(context.Context) error {
+			ch <- struct{}{}
+			time.Sleep(2 * time.Millisecond)
+			return nil
+		}))
+
+		wg.Add(3)
+		go func() {
+			defer wg.Done()
+			go func() {
+				defer wg.Done()
+				assert.NoError(t, job.Run(ctx))
+			}()
+
+			time.Sleep(10 * time.Millisecond)
+
+			go func() {
+				defer wg.Done()
+				assert.NoError(t, job.Run(ctx))
+			}()
+		}()
+		wg.Wait()
+
+		assert.Len(t, ch, 2)
+	})
+
+	t.Run("second run skipped if first not done", func(t *testing.T) {
+		buf.Reset()
+		ch := make(chan struct{}, 10)
+		job := noOverlapping(cron.JobFunc(func(context.Context) error {
+			ch <- struct{}{}
+			time.Sleep(10 * time.Millisecond)
+			return nil
+		}))
+
+		wg.Add(3)
+		go func() {
+			defer wg.Done()
+			go func() {
+				defer wg.Done()
+				assert.NoError(t, job.Run(ctx))
+			}()
+
+			go func() {
+				defer wg.Done()
+				assert.NoError(t, job.Run(ctx))
+			}()
+		}()
+		wg.Wait()
+
+		assert.Len(t, ch, 1)
+		assert.Contains(t, buf.String(), "job is still running, skip")
+	})
+
+	t.Run("skip 10 jobs on rapid fire", func(t *testing.T) {
+		buf.Reset()
+		ch := make(chan struct{}, 10)
+		job := noOverlapping(cron.JobFunc(func(context.Context) error {
+			ch <- struct{}{}
+			time.Sleep(100 * time.Millisecond)
+			return nil
+		}))
+
+		wg.Add(10)
+		for i := 0; i < 10; i++ {
+			go func() {
+				defer wg.Done()
+				assert.NoError(t, job.Run(ctx))
+			}()
+		}
+		wg.Wait()
+
+		assert.Len(t, ch, 1)
+		assert.Contains(t, buf.String(), "job is still running, skip")
+	})
+
+	t.Run("different jobs independent", func(t *testing.T) {
+		buf.Reset()
+		ch := make(chan struct{}, 100)
+		job1 := noOverlapping(cron.JobFunc(func(context.Context) error {
+			ch <- struct{}{}
+			time.Sleep(100 * time.Millisecond)
+			return nil
+		}))
+		job2 := noOverlapping(cron.JobFunc(func(context.Context) error {
+			ch <- struct{}{}
+			time.Sleep(100 * time.Millisecond)
+			return nil
+		}))
+
+		for i := 0; i < 10; i++ {
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				assert.NoError(t, job1.Run(ctx))
+			}()
+			go func() {
+				defer wg.Done()
+				assert.NoError(t, job2.Run(ctx))
+			}()
+		}
+
+		wg.Wait()
+		assert.Len(t, ch, 2)
+		assert.Contains(t, buf.String(), "job is still running, skip")
+	})
+}

--- a/middleware/nooverlapping/nooverlapping_test.go
+++ b/middleware/nooverlapping/nooverlapping_test.go
@@ -1,0 +1,128 @@
+package nooverlapping
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/flc1125/go-cron/v4"
+	"github.com/flc1125/go-cron/v4/internal/logger"
+)
+
+var ctx = context.Background()
+
+func TestNoOverlapping(t *testing.T) {
+	var (
+		buf = logger.NewBuffer()
+		m   = New(WithLogger(logger.NewBufferLogger(buf)))
+		ch  = make(chan struct{}, 100)
+		wg  = sync.WaitGroup{}
+		job = m(cron.JobFunc(func(context.Context) error {
+			ch <- struct{}{}
+			time.Sleep(2 * time.Millisecond)
+			return nil
+		}))
+	)
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			assert.NoError(t, job.Run(ctx))
+		}()
+	}
+	wg.Wait()
+
+	assert.Len(t, ch, 1)
+	assert.Contains(t, buf.String(), "job is still running, skip")
+}
+
+// func TestChainSkipIfStillRunning(t *testing.T) {
+// 	t.Run("runs immediately", func(t *testing.T) {
+// 		var j countJob
+// 		wrappedJob := Chain(SkipIfStillRunning(DiscardLogger))(&j)
+// 		go wrappedJob.Run(context.Background()) //nolint:errcheck
+// 		time.Sleep(20 * time.Millisecond)       // Give the job 2ms to complete.
+// 		if c := j.Done(); c != 1 {
+// 			t.Errorf("expected job run once, immediately, got %d", c)
+// 		}
+// 	})
+//
+// 	t.Run("second run immediate if first done", func(t *testing.T) {
+// 		var j countJob
+// 		wrappedJob := Chain(SkipIfStillRunning(DiscardLogger))(&j)
+// 		go func() {
+// 			go wrappedJob.Run(context.Background()) //nolint:errcheck
+// 			time.Sleep(10 * time.Millisecond)
+// 			go wrappedJob.Run(context.Background()) //nolint:errcheck
+// 		}()
+// 		time.Sleep(30 * time.Millisecond) // Give both jobs 3ms to complete.
+// 		if c := j.Done(); c != 2 {
+// 			t.Errorf("expected job run twice, immediately, got %d", c)
+// 		}
+// 	})
+//
+// 	t.Run("second run skipped if first not done", func(t *testing.T) {
+// 		var j countJob
+// 		j.delay = 10 * time.Millisecond
+// 		wrappedJob := Chain(SkipIfStillRunning(DiscardLogger))(&j)
+// 		go func() {
+// 			go wrappedJob.Run(context.Background()) //nolint:errcheck
+// 			time.Sleep(time.Millisecond)
+// 			go wrappedJob.Run(context.Background()) //nolint:errcheck
+// 		}()
+//
+// 		// After 5ms, the first job is still in progress, and the second job was
+// 		// aleady skipped.
+// 		time.Sleep(5 * time.Millisecond)
+// 		started, done := j.Started(), j.Done()
+// 		if started != 1 || done != 0 {
+// 			t.Error("expected first job started, but not finished, got", started, done)
+// 		}
+//
+// 		// Verify that the first job completes and second does not run.
+// 		time.Sleep(25 * time.Millisecond)
+// 		started, done = j.Started(), j.Done()
+// 		if started != 1 || done != 1 {
+// 			t.Error("expected second job skipped, got", started, done)
+// 		}
+// 	})
+//
+// 	t.Run("skip 10 jobs on rapid fire", func(t *testing.T) {
+// 		var j countJob
+// 		j.delay = 10 * time.Millisecond
+// 		wrappedJob := Chain(SkipIfStillRunning(DiscardLogger))(&j)
+// 		for i := 0; i < 11; i++ {
+// 			go wrappedJob.Run(context.Background()) //nolint:errcheck
+// 		}
+// 		time.Sleep(200 * time.Millisecond)
+// 		done := j.Done()
+// 		if done != 1 {
+// 			t.Error("expected 1 jobs executed, 10 jobs dropped, got", done)
+// 		}
+// 	})
+//
+// 	t.Run("different jobs independent", func(t *testing.T) {
+// 		var j1, j2 countJob
+// 		j1.delay = 10 * time.Millisecond
+// 		j2.delay = 10 * time.Millisecond
+// 		chain := Chain(SkipIfStillRunning(DiscardLogger))
+// 		wrappedJob1 := chain(&j1)
+// 		wrappedJob2 := chain(&j2)
+// 		for i := 0; i < 11; i++ {
+// 			go wrappedJob1.Run(context.Background()) //nolint:errcheck
+// 			go wrappedJob2.Run(context.Background()) //nolint:errcheck
+// 		}
+// 		time.Sleep(100 * time.Millisecond)
+// 		var (
+// 			done1 = j1.Done()
+// 			done2 = j2.Done()
+// 		)
+// 		if done1 != 1 || done2 != 1 {
+// 			t.Error("expected both jobs executed once, got", done1, "and", done2)
+// 		}
+// 	})
+// }


### PR DESCRIPTION
closed: https://github.com/flc1125/go-cron/issues/18