### PR TITLE
chore(Makefile): add clean target to remove tools and coverage files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,3 +145,8 @@ COMMIT ?= "HEAD"
 add-tags: verify-mods
 	@[ "${MODSET}" ] || ( echo ">> env var MODSET is not set"; exit 1 )
 	$(MULTIMOD) tag -m ${MODSET} -c ${COMMIT}
+
+.PHONY: clean
+clean:
+	@rm -rf $(TOOLS)
+	@rm -rf coverage.txt coverage.out coverage.html


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added a new `clean` target to the Makefile for removing build artifacts and coverage files
	- Improved Makefile formatting with a minor newline addition

<!-- end of auto-generated comment: release notes by coderabbit.ai -->