### PR TITLE
chore: update Go version to 1.23 across modules and configuration files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: 1.23.x
           check-latest: true
           cache-dependency-path: "**/go.sum"
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version: 1.23.6
           check-latest: true
           cache-dependency-path: "**/go.sum"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     name: "go test"
     strategy:
       matrix:
-        go-version: [ 1.22.x, 1.23.x, 1.24.x ]
+        go-version: [ 1.23.x, 1.24.x ]
         platform: [ ubuntu-latest ]
     runs-on: ${{ matrix.platform }}
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cron
 
-![Supported Go Versions](https://img.shields.io/badge/Go-%3E%3D1.22-blue)
+![Supported Go Versions](https://img.shields.io/badge/Go-%3E%3D1.23-blue)
 [![Package Version](https://badgen.net/github/release/flc1125/go-cron/stable)](https://github.com/flc1125/go-cron/releases)
 [![GoDoc](https://pkg.go.dev/badge/github.com/flc1125/go-cron/v4)](https://pkg.go.dev/github.com/flc1125/go-cron/v4)
 [![codecov](https://codecov.io/gh/flc1125/go-cron/graph/badge.svg?token=mXNvrv22JH)](https://codecov.io/gh/flc1125/go-cron)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cron
 
-![Supported Go Versions](https://img.shields.io/badge/Go-%3E%3D1.23-blue)
+![Supported Go Versions](https://img.shields.io/badge/Go-%3E%3D1.23.6-blue)
 [![Package Version](https://badgen.net/github/release/flc1125/go-cron/stable)](https://github.com/flc1125/go-cron/releases)
 [![GoDoc](https://pkg.go.dev/badge/github.com/flc1125/go-cron/v4)](https://pkg.go.dev/github.com/flc1125/go-cron/v4)
 [![codecov](https://codecov.io/gh/flc1125/go-cron/graph/badge.svg?token=mXNvrv22JH)](https://codecov.io/gh/flc1125/go-cron)

--- a/crontest/go.mod
+++ b/crontest/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-cron/crontest/v4
 
-go 1.22.0
+go 1.23
 
 replace github.com/flc1125/go-cron/v4 => ../
 

--- a/crontest/go.mod
+++ b/crontest/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-cron/crontest/v4
 
-go 1.23
+go 1.23.6
 
 replace github.com/flc1125/go-cron/v4 => ../
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-cron/v4
 
-go 1.23
+go 1.23.6
 
 require github.com/stretchr/testify v1.10.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-cron/v4
 
-go 1.22.0
+go 1.23
 
 require github.com/stretchr/testify v1.10.0
 

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-cron/v4/internal/tools
 
-go 1.22.10
+go 1.23
 
 require (
 	github.com/golangci/golangci-lint v1.63.4

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-cron/v4/internal/tools
 
-go 1.23
+go 1.23.6
 
 require (
 	github.com/golangci/golangci-lint v1.63.4

--- a/middleware/delayoverlapping/go.mod
+++ b/middleware/delayoverlapping/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-cron/middleware/delayoverlapping/v4
 
-go 1.22.0
+go 1.23
 
 replace (
 	github.com/flc1125/go-cron/crontest/v4 => ../../crontest

--- a/middleware/delayoverlapping/go.mod
+++ b/middleware/delayoverlapping/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-cron/middleware/delayoverlapping/v4
 
-go 1.23
+go 1.23.6
 
 replace (
 	github.com/flc1125/go-cron/crontest/v4 => ../../crontest

--- a/middleware/distributednooverlapping/go.mod
+++ b/middleware/distributednooverlapping/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-cron/middleware/distributednooverlapping/v4
 
-go 1.23
+go 1.23.6
 
 replace (
 	github.com/flc1125/go-cron/crontest/v4 => ../../crontest

--- a/middleware/distributednooverlapping/go.mod
+++ b/middleware/distributednooverlapping/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-cron/middleware/distributednooverlapping/v4
 
-go 1.22.0
+go 1.23
 
 replace (
 	github.com/flc1125/go-cron/crontest/v4 => ../../crontest

--- a/middleware/distributednooverlapping/redismutex/go.mod
+++ b/middleware/distributednooverlapping/redismutex/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-cron/middleware/distributednooverlapping/redismutex/v4
 
-go 1.23
+go 1.23.6
 
 replace (
 	github.com/flc1125/go-cron/crontest/v4 => ../../../crontest

--- a/middleware/distributednooverlapping/redismutex/go.mod
+++ b/middleware/distributednooverlapping/redismutex/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-cron/middleware/distributednooverlapping/redismutex/v4
 
-go 1.22.0
+go 1.23
 
 replace (
 	github.com/flc1125/go-cron/crontest/v4 => ../../../crontest

--- a/middleware/nooverlapping/go.mod
+++ b/middleware/nooverlapping/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-cron/middleware/nooverlapping/v4
 
-go 1.23
+go 1.23.6
 
 replace (
 	github.com/flc1125/go-cron/crontest/v4 => ../../crontest

--- a/middleware/nooverlapping/go.mod
+++ b/middleware/nooverlapping/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-cron/middleware/nooverlapping/v4
 
-go 1.22.0
+go 1.23
 
 replace (
 	github.com/flc1125/go-cron/crontest/v4 => ../../crontest

--- a/middleware/otel/go.mod
+++ b/middleware/otel/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-cron/middleware/otel/v4
 
-go 1.23
+go 1.23.6
 
 replace github.com/flc1125/go-cron/v4 => ../../
 

--- a/middleware/otel/go.mod
+++ b/middleware/otel/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-cron/middleware/otel/v4
 
-go 1.22.0
+go 1.23
 
 replace github.com/flc1125/go-cron/v4 => ../../
 

--- a/middleware/recovery/go.mod
+++ b/middleware/recovery/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-cron/middleware/recovery/v4
 
-go 1.22.0
+go 1.23
 
 replace (
 	github.com/flc1125/go-cron/crontest/v4 => ../../crontest

--- a/middleware/recovery/go.mod
+++ b/middleware/recovery/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-cron/middleware/recovery/v4
 
-go 1.23
+go 1.23.6
 
 replace (
 	github.com/flc1125/go-cron/crontest/v4 => ../../crontest

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
   "separateMajorMinor": true,
   "postUpdateOptions": ["gomodTidy"],
   "constraints": {
-    "go": "1.22.0"
+    "go": "1.23"
   },
   "packageRules": [
     {
@@ -18,7 +18,7 @@
     {
       "matchFileNames": ["internal/tools/go.mod"],
       "constraints": {
-        "go": "1.22.10"
+        "go": "1.23"
       },
       "enabled": true
     }

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
   "separateMajorMinor": true,
   "postUpdateOptions": ["gomodTidy"],
   "constraints": {
-    "go": "1.23"
+    "go": "1.23.6"
   },
   "packageRules": [
     {
@@ -18,7 +18,7 @@
     {
       "matchFileNames": ["internal/tools/go.mod"],
       "constraints": {
-        "go": "1.23"
+        "go": "1.23.6"
       },
       "enabled": true
     }

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-cron/tests/v4
 
-go 1.22.0
+go 1.23
 
 replace (
 	github.com/flc1125/go-cron/crontest/v4 => ../crontest

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-cron/tests/v4
 
-go 1.23
+go 1.23.6
 
 replace (
 	github.com/flc1125/go-cron/crontest/v4 => ../crontest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Fixed the Go version across CI workflows and module configurations to consistently use version 1.23. This change helps maintain a stable and predictable build and test environment while aligning dependency constraints.
- **Documentation**
	- Updated project documentation to reflect the new minimum requirement of Go ≥ 1.23.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->