### PR TITLE
Release v4.5.6

### DIFF
--- a/crontest/go.mod
+++ b/crontest/go.mod
@@ -4,4 +4,4 @@ go 1.23.0
 
 replace github.com/flc1125/go-cron/v4 => ../
 
-require github.com/flc1125/go-cron/v4 v4.5.5
+require github.com/flc1125/go-cron/v4 v4.5.6

--- a/middleware/delayoverlapping/go.mod
+++ b/middleware/delayoverlapping/go.mod
@@ -8,8 +8,8 @@ replace (
 )
 
 require (
-	github.com/flc1125/go-cron/crontest/v4 v4.5.5
-	github.com/flc1125/go-cron/v4 v4.5.5
+	github.com/flc1125/go-cron/crontest/v4 v4.5.6
+	github.com/flc1125/go-cron/v4 v4.5.6
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/middleware/distributednooverlapping/go.mod
+++ b/middleware/distributednooverlapping/go.mod
@@ -8,8 +8,8 @@ replace (
 )
 
 require (
-	github.com/flc1125/go-cron/crontest/v4 v4.5.5
-	github.com/flc1125/go-cron/v4 v4.5.5
+	github.com/flc1125/go-cron/crontest/v4 v4.5.6
+	github.com/flc1125/go-cron/v4 v4.5.6
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/middleware/distributednooverlapping/redismutex/go.mod
+++ b/middleware/distributednooverlapping/redismutex/go.mod
@@ -9,8 +9,8 @@ replace (
 )
 
 require (
-	github.com/flc1125/go-cron/middleware/distributednooverlapping/v4 v4.5.5
-	github.com/flc1125/go-cron/v4 v4.5.5
+	github.com/flc1125/go-cron/middleware/distributednooverlapping/v4 v4.5.6
+	github.com/flc1125/go-cron/v4 v4.5.6
 	github.com/redis/go-redis/v9 v9.10.0
 	github.com/stretchr/testify v1.10.0
 )

--- a/middleware/nooverlapping/go.mod
+++ b/middleware/nooverlapping/go.mod
@@ -8,8 +8,8 @@ replace (
 )
 
 require (
-	github.com/flc1125/go-cron/crontest/v4 v4.5.5
-	github.com/flc1125/go-cron/v4 v4.5.5
+	github.com/flc1125/go-cron/crontest/v4 v4.5.6
+	github.com/flc1125/go-cron/v4 v4.5.6
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/middleware/otel/go.mod
+++ b/middleware/otel/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 replace github.com/flc1125/go-cron/v4 => ../../
 
 require (
-	github.com/flc1125/go-cron/v4 v4.5.5
+	github.com/flc1125/go-cron/v4 v4.5.6
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/otel v1.36.0
 	go.opentelemetry.io/otel/sdk v1.36.0

--- a/middleware/recovery/go.mod
+++ b/middleware/recovery/go.mod
@@ -8,8 +8,8 @@ replace (
 )
 
 require (
-	github.com/flc1125/go-cron/crontest/v4 v4.5.5
-	github.com/flc1125/go-cron/v4 v4.5.5
+	github.com/flc1125/go-cron/crontest/v4 v4.5.6
+	github.com/flc1125/go-cron/v4 v4.5.6
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -13,12 +13,12 @@ replace (
 )
 
 require (
-	github.com/flc1125/go-cron/middleware/distributednooverlapping/redismutex/v4 v4.5.5
-	github.com/flc1125/go-cron/middleware/distributednooverlapping/v4 v4.5.5
-	github.com/flc1125/go-cron/middleware/nooverlapping/v4 v4.5.5
-	github.com/flc1125/go-cron/middleware/otel/v4 v4.5.5
-	github.com/flc1125/go-cron/middleware/recovery/v4 v4.5.5
-	github.com/flc1125/go-cron/v4 v4.5.5
+	github.com/flc1125/go-cron/middleware/distributednooverlapping/redismutex/v4 v4.5.6
+	github.com/flc1125/go-cron/middleware/distributednooverlapping/v4 v4.5.6
+	github.com/flc1125/go-cron/middleware/nooverlapping/v4 v4.5.6
+	github.com/flc1125/go-cron/middleware/otel/v4 v4.5.6
+	github.com/flc1125/go-cron/middleware/recovery/v4 v4.5.6
+	github.com/flc1125/go-cron/v4 v4.5.6
 	github.com/redis/go-redis/v9 v9.10.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/otel/sdk v1.36.0

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package cron
 
 func Version() string {
-	return "4.5.5"
+	return "4.5.6"
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 module-sets:
   stable:
-    version: v4.5.5
+    version: v4.5.6
     modules:
       # Core modules
       - github.com/flc1125/go-cron/v4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated dependencies to use version v4.5.6 of the go-cron modules across all relevant components.
	- Updated the reported version number to 4.5.6 in version displays and configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->