### PR TITLE
feat: group go.opentelemetry.io/build-tools dependencies in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,6 +26,10 @@
     {
       "matchPackageNames": ["golang.org/x/**"],
       "groupName": "golang.org/x"
+    },
+    {
+      "matchPackageNames": ["go.opentelemetry.io/build-tools/**"],
+      "groupName": "opentelemetry-build-tools"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add grouping rule for `go.opentelemetry.io/build-tools/**` dependencies in Renovate configuration
- This will group all OpenTelemetry build tools updates into a single PR to reduce noise

## Changes
- Added new package rule in `renovate.json` to group `go.opentelemetry.io/build-tools/**` dependencies under the group name `opentelemetry-build-tools`

## Test plan
- [ ] Verify Renovate configuration is valid
- [ ] Wait for next Renovate run to confirm grouping works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to better group related OpenTelemetry build tool packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->