### PR TITLE
chore: bump supported Go versions to 1.25 and 1.26

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.24.0
+          go-version: 1.26.x
           check-latest: true
           cache-dependency-path: "**/go.sum"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     name: "go test"
     strategy:
       matrix:
-        go-version: [ 1.24.x, 1.25.x ]
+        go-version: [ 1.25.x, 1.26.x ]
         platform: [ ubuntu-latest ]
     runs-on: ${{ matrix.platform }}
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cron
 
-![Supported Go Versions](https://img.shields.io/badge/Go-%3E%3D1.24.0-blue)
+![Supported Go Versions](https://img.shields.io/badge/Go-%3E%3D1.25.0-blue)
 [![Package Version](https://badgen.net/github/release/flc1125/go-cron/stable)](https://github.com/flc1125/go-cron/releases)
 [![GoDoc](https://pkg.go.dev/badge/github.com/flc1125/go-cron/v4)](https://pkg.go.dev/github.com/flc1125/go-cron/v4)
 [![codecov](https://codecov.io/gh/flc1125/go-cron/graph/badge.svg?token=mXNvrv22JH)](https://codecov.io/gh/flc1125/go-cron)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-cron/v4
 
-go 1.24.0
+go 1.25.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/gomod_test.go
+++ b/gomod_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var expectedVersion = "go 1.24.0"
+var expectedVersion = "go 1.25.0"
 
 func TestAllGoModVersions(t *testing.T) {
 	var modFiles []string

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-cron/v4/internal/tools
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/golangci/golangci-lint/v2 v2.8.0

--- a/middleware/delayoverlapping/go.mod
+++ b/middleware/delayoverlapping/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-cron/middleware/delayoverlapping/v4
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/flc1125/go-cron/v4 => ../../
 

--- a/middleware/distributednooverlapping/go.mod
+++ b/middleware/distributednooverlapping/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-cron/middleware/distributednooverlapping/v4
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/flc1125/go-cron/v4 => ../../
 

--- a/middleware/distributednooverlapping/redismutex/go.mod
+++ b/middleware/distributednooverlapping/redismutex/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-cron/middleware/distributednooverlapping/redismutex/v4
 
-go 1.24.0
+go 1.25.0
 
 replace (
 	github.com/flc1125/go-cron/middleware/distributednooverlapping/v4 => ../

--- a/middleware/nooverlapping/go.mod
+++ b/middleware/nooverlapping/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-cron/middleware/nooverlapping/v4
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/flc1125/go-cron/v4 => ../../
 

--- a/middleware/otel/go.mod
+++ b/middleware/otel/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-cron/middleware/otel/v4
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/flc1125/go-cron/v4 => ../../
 

--- a/middleware/recovery/go.mod
+++ b/middleware/recovery/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-cron/middleware/recovery/v4
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/flc1125/go-cron/v4 => ../../
 

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
   "separateMajorMinor": true,
   "postUpdateOptions": ["gomodTidy"],
   "constraints": {
-    "go": "1.24.0"
+    "go": "1.25.0"
   },
   "packageRules": [
     {
@@ -19,7 +19,7 @@
     {
       "matchFileNames": ["internal/tools/go.mod"],
       "constraints": {
-        "go": "1.24.0"
+        "go": "1.25.0"
       },
       "enabled": true
     },

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/flc1125/go-cron/tests/v4
 
-go 1.24.0
+go 1.25.0
 
 replace (
 	github.com/flc1125/go-cron/middleware/distributednooverlapping/redismutex/v4 => ../middleware/distributednooverlapping/redismutex


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum supported Go version from 1.24.0 to 1.25.0.
  * Expanded test coverage to include Go 1.26.x.
  * Dropped support for Go 1.24.x.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->