### PR TITLE
chore(release): prepare stable for v4.9.0

### DIFF
--- a/middleware/delayoverlapping/go.mod
+++ b/middleware/delayoverlapping/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/flc1125/go-cron/v4 => ../../
 
 require (
-	github.com/flc1125/go-cron/v4 v4.8.1
+	github.com/flc1125/go-cron/v4 v4.9.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/middleware/distributednooverlapping/go.mod
+++ b/middleware/distributednooverlapping/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/flc1125/go-cron/v4 => ../../
 
 require (
-	github.com/flc1125/go-cron/v4 v4.8.1
+	github.com/flc1125/go-cron/v4 v4.9.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/middleware/distributednooverlapping/redismutex/go.mod
+++ b/middleware/distributednooverlapping/redismutex/go.mod
@@ -8,8 +8,8 @@ replace (
 )
 
 require (
-	github.com/flc1125/go-cron/middleware/distributednooverlapping/v4 v4.8.1
-	github.com/flc1125/go-cron/v4 v4.8.1
+	github.com/flc1125/go-cron/middleware/distributednooverlapping/v4 v4.9.0
+	github.com/flc1125/go-cron/v4 v4.9.0
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/middleware/nooverlapping/go.mod
+++ b/middleware/nooverlapping/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/flc1125/go-cron/v4 => ../../
 
 require (
-	github.com/flc1125/go-cron/v4 v4.8.1
+	github.com/flc1125/go-cron/v4 v4.9.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/middleware/otel/go.mod
+++ b/middleware/otel/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/flc1125/go-cron/v4 => ../../
 
 require (
-	github.com/flc1125/go-cron/v4 v4.8.1
+	github.com/flc1125/go-cron/v4 v4.9.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0

--- a/middleware/recovery/go.mod
+++ b/middleware/recovery/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/flc1125/go-cron/v4 => ../../
 
 require (
-	github.com/flc1125/go-cron/v4 v4.8.1
+	github.com/flc1125/go-cron/v4 v4.9.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -12,12 +12,12 @@ replace (
 )
 
 require (
-	github.com/flc1125/go-cron/middleware/distributednooverlapping/redismutex/v4 v4.8.1
-	github.com/flc1125/go-cron/middleware/distributednooverlapping/v4 v4.8.1
-	github.com/flc1125/go-cron/middleware/nooverlapping/v4 v4.8.1
-	github.com/flc1125/go-cron/middleware/otel/v4 v4.8.1
-	github.com/flc1125/go-cron/middleware/recovery/v4 v4.8.1
-	github.com/flc1125/go-cron/v4 v4.8.1
+	github.com/flc1125/go-cron/middleware/distributednooverlapping/redismutex/v4 v4.9.0
+	github.com/flc1125/go-cron/middleware/distributednooverlapping/v4 v4.9.0
+	github.com/flc1125/go-cron/middleware/nooverlapping/v4 v4.9.0
+	github.com/flc1125/go-cron/middleware/otel/v4 v4.9.0
+	github.com/flc1125/go-cron/middleware/recovery/v4 v4.9.0
+	github.com/flc1125/go-cron/v4 v4.9.0
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel/sdk v1.43.0

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package cron
 
 func Version() string {
-	return "4.8.1"
+	return "4.9.0"
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 module-sets:
   stable:
-    version: v4.8.1
+    version: v4.9.0
     modules:
       # Core modules
       - github.com/flc1125/go-cron/v4


### PR DESCRIPTION
## Summary
Prepare the stable module set for the v4.9.0 release.

## Changes
- bump the stable module-set version from `v4.8.1` to `v4.9.0` in `versions.yaml`
- update `version.go` and dependent module `go.mod` files to reference `v4.9.0`
- align the test module dependencies with the v4.9.0 release line

## Motivation
- keep the stable release branch and published module references aligned for the v4.9.0 release

## Testing
- not run as part of PR creation