### PR TITLE
fix(distributednooverlapping)!: bind unlock to lock handle

### DIFF
--- a/middleware/distributednooverlapping/README.md
+++ b/middleware/distributednooverlapping/README.md
@@ -8,6 +8,7 @@ This middleware is used to prevent the overlapping of the cron job in a distribu
 - Configurable mutex TTL and key prefixes
 - Automatic lock release on job completion
 - Graceful handling of network partitions
+- Lock ownership is bound to the acquired lock handle
 
 ## Usage
 
@@ -81,3 +82,26 @@ output:
 2024/12/06 10:35:15 running job one
 2024/12/06 10:35:17 running job two
 ```
+
+## Custom Mutex
+
+Custom mutex implementations must return a lock handle when the lock is
+acquired. The middleware unlocks that handle after the job finishes.
+
+```go
+type Mutex interface {
+	Lock(ctx context.Context, job JobWithMutex) (Lock, bool, error)
+}
+
+type Lock interface {
+	Unlock(ctx context.Context) error
+}
+```
+
+Binding `Unlock` to the returned lock handle is intentional. Distributed locks
+usually need ownership data, such as a Redis token, to make unlock safe. If a
+job runs longer than the lock TTL, another worker may acquire the same key. A
+stale worker must not be able to delete that successor lock.
+
+The Redis mutex stores an owner token for each acquired lock and releases it
+with an atomic compare-and-delete operation.

--- a/middleware/distributednooverlapping/distributednooverlapping.go
+++ b/middleware/distributednooverlapping/distributednooverlapping.go
@@ -46,7 +46,7 @@ func New(mu Mutex, opts ...Option) cron.Middleware {
 				return original.Run(ctx)
 			}
 
-			acquired, err := o.mu.Lock(ctx, job)
+			lock, acquired, err := o.mu.Lock(ctx, job)
 			if err != nil {
 				o.logger.Error(err, "failed to lock mutex", "mutex key", job.GetMutexKey())
 				return err
@@ -57,7 +57,7 @@ func New(mu Mutex, opts ...Option) cron.Middleware {
 			}
 
 			defer func() {
-				if err := o.mu.Unlock(ctx, job); err != nil {
+				if err := lock.Unlock(ctx); err != nil {
 					o.logger.Error(err, "failed to unlock mutex", "key", job.GetMutexKey())
 				}
 			}()

--- a/middleware/distributednooverlapping/distributednooverlapping_test.go
+++ b/middleware/distributednooverlapping/distributednooverlapping_test.go
@@ -46,16 +46,12 @@ type testMutex struct {
 
 var _ Mutex = testMutex{}
 
-func (m testMutex) Lock(_ context.Context, job JobWithMutex) (bool, error) {
+func (m testMutex) Lock(_ context.Context, job JobWithMutex) (Lock, bool, error) {
 	if job.GetMutexKey() == "test" {
-		return true, nil
+		return noopLock{}, true, nil
 	}
 
-	return false, nil
-}
-
-func (m testMutex) Unlock(context.Context, JobWithMutex) error {
-	return nil
+	return nil, false, nil
 }
 
 func TestMiddleware_Noop(t *testing.T) {

--- a/middleware/distributednooverlapping/mutex.go
+++ b/middleware/distributednooverlapping/mutex.go
@@ -9,12 +9,15 @@ import (
 
 type Mutex interface {
 	// Lock tries to acquire the mutex for the job.
+	// If the mutex is acquired, it returns a lock that must be unlocked.
 	// If the mutex is acquired, it returns true.
 	// If the mutex is not acquired, it returns false.
-	Lock(ctx context.Context, job JobWithMutex) (bool, error)
+	Lock(ctx context.Context, job JobWithMutex) (Lock, bool, error)
+}
 
-	// Unlock releases the mutex for the job.
-	Unlock(ctx context.Context, job JobWithMutex) error
+type Lock interface {
+	// Unlock releases the acquired lock.
+	Unlock(ctx context.Context) error
 }
 
 type JobWithMutex interface {
@@ -30,10 +33,12 @@ type JobWithMutex interface {
 
 type NoopMutex struct{}
 
-func (m NoopMutex) Lock(context.Context, JobWithMutex) (bool, error) {
-	return true, nil
+func (m NoopMutex) Lock(context.Context, JobWithMutex) (Lock, bool, error) {
+	return noopLock{}, true, nil
 }
 
-func (m NoopMutex) Unlock(context.Context, JobWithMutex) error {
+type noopLock struct{}
+
+func (m noopLock) Unlock(context.Context) error {
 	return nil
 }

--- a/middleware/distributednooverlapping/mutex_test.go
+++ b/middleware/distributednooverlapping/mutex_test.go
@@ -10,10 +10,11 @@ func TestMutex_NoopMutex(t *testing.T) {
 	m := NoopMutex{}
 	ctx := t.Context()
 
-	acquired, err := m.Lock(ctx, nil)
+	lock, acquired, err := m.Lock(ctx, nil)
 	assert.NoError(t, err)
 	assert.True(t, acquired)
+	assert.NotNil(t, lock)
 
-	err = m.Unlock(ctx, nil)
+	err = lock.Unlock(ctx)
 	assert.NoError(t, err)
 }

--- a/middleware/distributednooverlapping/redismutex/mutex.go
+++ b/middleware/distributednooverlapping/redismutex/mutex.go
@@ -2,6 +2,9 @@ package redismutex
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
 
 	"github.com/flc1125/go-cron/middleware/distributednooverlapping/v4"
 	redis "github.com/redis/go-redis/v9"
@@ -29,6 +32,13 @@ func WithPrefix(prefix string) Option {
 
 var _ distributednooverlapping.Mutex = (*Mutex)(nil)
 
+var unlockScript = redis.NewScript(`
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+	return redis.call("DEL", KEYS[1])
+end
+return 0
+`)
+
 func New(redis redis.UniversalClient, opts ...Option) *Mutex {
 	mutex := &Mutex{
 		redis:  redis,
@@ -40,10 +50,43 @@ func New(redis redis.UniversalClient, opts ...Option) *Mutex {
 	return mutex
 }
 
-func (m *Mutex) Lock(ctx context.Context, job distributednooverlapping.JobWithMutex) (bool, error) {
-	return m.redis.SetNX(ctx, m.prefix+job.GetMutexKey(), 1, job.GetMutexTTL()).Result()
+func (m *Mutex) Lock(ctx context.Context, job distributednooverlapping.JobWithMutex) (distributednooverlapping.Lock, bool, error) {
+	key := m.key(job)
+	token, err := newToken()
+	if err != nil {
+		return nil, false, err
+	}
+
+	acquired, err := m.redis.SetNX(ctx, key, token, job.GetMutexTTL()).Result()
+	if err != nil || !acquired {
+		return nil, acquired, err
+	}
+
+	return &lock{
+		redis: m.redis,
+		key:   key,
+		token: token,
+	}, true, nil
 }
 
-func (m *Mutex) Unlock(ctx context.Context, job distributednooverlapping.JobWithMutex) error {
-	return m.redis.Del(ctx, m.prefix+job.GetMutexKey()).Err()
+type lock struct {
+	redis redis.UniversalClient
+	key   string
+	token string
+}
+
+func (l *lock) Unlock(ctx context.Context) error {
+	return unlockScript.Run(ctx, l.redis, []string{l.key}, l.token).Err()
+}
+
+func newToken() (string, error) {
+	var token [32]byte
+	if _, err := rand.Read(token[:]); err != nil {
+		return "", fmt.Errorf("generate redis mutex token: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(token[:]), nil
+}
+
+func (m *Mutex) key(job distributednooverlapping.JobWithMutex) string {
+	return m.prefix + job.GetMutexKey()
 }

--- a/middleware/distributednooverlapping/redismutex/mutex_test.go
+++ b/middleware/distributednooverlapping/redismutex/mutex_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/flc1125/go-cron/v4"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var ctx = context.Background()
@@ -59,25 +60,29 @@ func TestMutex(t *testing.T) {
 			ttl:  time.Second,
 		}
 
-		acquired, err := mutex.Lock(ctx, job)
+		lock, acquired, err := mutex.Lock(ctx, job)
 		assert.NoError(t, err)
 		assert.True(t, acquired)
+		assert.NotNil(t, lock)
 
-		acquired, err = mutex.Lock(ctx, job)
+		_, acquired, err = mutex.Lock(ctx, job)
 		assert.NoError(t, err)
 		assert.False(t, acquired)
 
-		time.Sleep(time.Second + time.Millisecond*10)
+		// unlock
+		err = lock.Unlock(ctx)
+		assert.NoError(t, err)
 
-		acquired, err = mutex.Lock(ctx, job)
+		lock, acquired, err = mutex.Lock(ctx, job)
 		assert.NoError(t, err)
 		assert.True(t, acquired)
+		assert.NotNil(t, lock)
 
 		// unlock
-		err = mutex.Unlock(ctx, job)
+		err = lock.Unlock(ctx)
 		assert.NoError(t, err)
 
-		acquired, err = mutex.Lock(ctx, job)
+		_, acquired, err = mutex.Lock(ctx, job)
 		assert.NoError(t, err)
 		assert.True(t, acquired)
 	})
@@ -102,43 +107,96 @@ func TestMutex(t *testing.T) {
 		}
 
 		// lock job1
-		acquired, err := mutex.Lock(ctx, job1)
+		lock1, acquired, err := mutex.Lock(ctx, job1)
 		assert.NoError(t, err)
 		assert.True(t, acquired)
+		assert.NotNil(t, lock1)
 
 		// lock job2
-		acquired, err = mutex.Lock(ctx, job2)
+		lock2, acquired, err := mutex.Lock(ctx, job2)
 		assert.NoError(t, err)
 		assert.True(t, acquired)
+		assert.NotNil(t, lock2)
 
-		acquired, err = mutex.Lock(ctx, job1)
+		_, acquired, err = mutex.Lock(ctx, job1)
 		assert.NoError(t, err)
 		assert.False(t, acquired)
 
-		acquired, err = mutex.Lock(ctx, job2)
+		_, acquired, err = mutex.Lock(ctx, job2)
 		assert.NoError(t, err)
 		assert.False(t, acquired)
 
 		// unlock job1
-		err = mutex.Unlock(ctx, job1)
+		err = lock1.Unlock(ctx)
 		assert.NoError(t, err)
 
-		acquired, err = mutex.Lock(ctx, job1)
+		lock1, acquired, err = mutex.Lock(ctx, job1)
 		assert.NoError(t, err)
 		assert.True(t, acquired)
+		assert.NotNil(t, lock1)
+
+		// unlock job1
+		err = lock1.Unlock(ctx)
+		assert.NoError(t, err)
 
 		// unlock job2
-		err = mutex.Unlock(ctx, job1)
+		err = lock2.Unlock(ctx)
 		assert.NoError(t, err)
 
-		// unlock
-		err = mutex.Unlock(ctx, job2)
-		assert.NoError(t, err)
-
-		acquired, err = mutex.Lock(ctx, job2)
+		_, acquired, err = mutex.Lock(ctx, job2)
 		assert.NoError(t, err)
 		assert.True(t, acquired)
 	})
+}
+
+func TestMutex_UnlockDoesNotDeleteSuccessorLock(t *testing.T) {
+	client := createRedis(t)
+	staleOwner := New(client, WithPrefix("test:cron"))
+	successor := New(client, WithPrefix("test:cron"))
+	contender := New(client, WithPrefix("test:cron"))
+
+	staleJob := testJob{
+		t: t,
+		job: func(context.Context) error {
+			return nil
+		},
+		name: "job:stale-owner",
+		ttl:  50 * time.Millisecond,
+	}
+	successorJob := testJob{
+		t: t,
+		job: func(context.Context) error {
+			return nil
+		},
+		name: staleJob.name,
+		ttl:  time.Second,
+	}
+
+	staleLock, acquired, err := staleOwner.Lock(ctx, staleJob)
+	require.NoError(t, err)
+	require.True(t, acquired)
+	require.NotNil(t, staleLock)
+
+	time.Sleep(staleJob.ttl + 25*time.Millisecond)
+
+	successorLock, acquired, err := successor.Lock(ctx, successorJob)
+	require.NoError(t, err)
+	require.True(t, acquired)
+	require.NotNil(t, successorLock)
+
+	err = staleLock.Unlock(ctx)
+	require.NoError(t, err)
+
+	_, acquired, err = contender.Lock(ctx, successorJob)
+	require.NoError(t, err)
+	assert.False(t, acquired, "stale unlock must not remove the successor lock")
+
+	err = successorLock.Unlock(ctx)
+	require.NoError(t, err)
+
+	_, acquired, err = contender.Lock(ctx, successorJob)
+	require.NoError(t, err)
+	assert.True(t, acquired)
 }
 
 func TestMutex_Prefix(t *testing.T) {


### PR DESCRIPTION
## Summary
Fix the Redis distributed mutex so unlock is bound to the lock instance that was actually acquired.

## Changes
- Change `distributednooverlapping.Mutex.Lock` to return a `Lock` handle
- Have the middleware call `lock.Unlock(ctx)` after the job finishes
- Store a random Redis owner token for each acquired lock
- Release Redis locks with atomic compare-and-delete
- Add a regression test proving a stale owner cannot delete a successor lock
- Document the custom mutex API shape and ownership rationale

## Motivation
- The previous Redis mutex stored a constant value and released with key-only `DEL`
- If a job exceeded its TTL, a stale worker could delete a later worker's lock and allow overlapping execution

## Breaking Changes
- Custom `distributednooverlapping.Mutex` implementations must now return a `distributednooverlapping.Lock` handle from `Lock`
- The old `Unlock(ctx, job)` method on the mutex itself is removed
- Existing users that only construct the middleware with the built-in Redis mutex, for example `distributednooverlapping.New(redismutex.New(...))`, should not need call-site changes
- Users with custom mutex implementations need to move unlock state into the returned lock handle

## Testing
- `env GOCACHE=/tmp/go-cron-gocache GOTMPDIR=/tmp go test ./...` in `middleware/distributednooverlapping`
- `env GOCACHE=/tmp/go-cron-gocache GOTMPDIR=/tmp go test ./...` in `middleware/distributednooverlapping/redismutex`
- `env GOCACHE=/tmp/go-cron-gocache GOTMPDIR=/tmp go test -race ./...` in `middleware/distributednooverlapping/redismutex`
- `env GOCACHE=/tmp/go-cron-gocache GOTMPDIR=/tmp go test ./...` at the repository root
- `env GOCACHE=/tmp/go-cron-gocache GOTMPDIR=/tmp go test ./...` in `tests`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated distributed lock middleware documentation with revised `Mutex` and `Lock` interface specifications describing ownership-bound lock handles.

* **Improvements**
  * Strengthened distributed lock safety with token-based lock handles, preventing accidental or unauthorized lock releases.
  * Enhanced lock ownership semantics through explicit handle-based unlock operations with atomic safety guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->