### PR TITLE
fix(cron): synchronize IsRunning state read

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -297,6 +297,8 @@ func (c *Cron) Stop() context.Context {
 
 // IsRunning returns true if the cron scheduler is started.
 func (c *Cron) IsRunning() bool {
+	c.runningMu.Lock()
+	defer c.runningMu.Unlock()
 	return c.running
 }
 

--- a/cron_test.go
+++ b/cron_test.go
@@ -779,6 +779,42 @@ func TestCron_IsRunning(t *testing.T) {
 	assert.False(t, c.IsRunning())
 }
 
+func TestCron_IsRunningConcurrentStartStop(t *testing.T) {
+	c := New()
+	const iterations = 100
+	const readers = 8
+
+	start := make(chan struct{})
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for range readers {
+		wg.Go(func() {
+			<-start
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					_ = c.IsRunning()
+				}
+			}
+		})
+	}
+
+	wg.Go(func() {
+		defer close(done)
+		<-start
+		for range iterations {
+			c.Start()
+			c.Stop()
+		}
+	})
+
+	close(start)
+	wg.Wait()
+}
+
 func TestMultiThreadedStartAndStop(*testing.T) {
 	cron := New()
 	go cron.Run()


### PR DESCRIPTION
## Summary
Fix a data race in Cron.IsRunning by synchronizing reads of the running state with the existing runningMu mutex.

## Changes
- Guard IsRunning reads of c.running with runningMu
- Add a race-focused regression test that concurrently calls IsRunning, Start, and Stop

## Motivation
- Start, Run, and Stop already write c.running under runningMu, but IsRunning previously read it without synchronization
- Concurrent lifecycle checks could trigger the Go race detector and read state unsafely

## Testing
- go test -race -run TestCron_IsRunningConcurrentStartStop ./...
- go test ./...