### PR TITLE
fix(distributednooverlapping)!: bind unlock to lock handle

### DIFF
--- a/middleware/distributednooverlapping/README.md
+++ b/middleware/distributednooverlapping/README.md
@@ -8,6 +8,7 @@ This middleware is used to prevent the overlapping of the cron job in a distribu
 - Configurable mutex TTL and key prefixes
 - Automatic lock release on job completion
 - Graceful handling of network partitions
+- Lock ownership is bound to the acquired lock handle
 
 ## Usage
 
@@ -81,3 +82,26 @@ output:
 2024/12/06 10:35:15 running job one
 2024/12/06 10:35:17 running job two
 ```
+
+## Custom Mutex
+
+Custom mutex implementations must return a lock handle when the lock is
+acquired. The middleware unlocks that handle after the job finishes.
+
+```go
+type Mutex interface {
+	Lock(ctx context.Context, job JobWithMutex) (Lock, bool, error)
+}
+
+type Lock interface {
+	Unlock(ctx context.Context) error
+}
+```
+
+Binding `Unlock` to the returned lock handle is intentional. Distributed locks
+usually need ownership data, such as a Redis token, to make unlock safe. If a
+job runs longer than the lock TTL, another worker may acquire the same key. A
+stale worker must not be able to delete that successor lock.
+
+The Redis mutex stores an owner token for each acquired lock and releases it
+with an atomic compare-and-delete operation.

--- a/middleware/distributednooverlapping/README.md
+++ b/middleware/distributednooverlapping/README.md
@@ -98,6 +98,16 @@ type Lock interface {
 }
 ```
 
+The return values from `Lock` must follow this contract:
+
+- If `acquired` is `true`, `Lock` must be non-nil.
+- If `acquired` is `false`, `Lock` should be nil.
+- If `err` is non-nil, `Lock` should be nil and `acquired` should be false.
+
+The middleware calls `Lock.Unlock(ctx)` only on the returned handle after a
+successful acquisition. Returning `acquired == true` with a nil lock is invalid
+and causes the middleware to return an error.
+
 Binding `Unlock` to the returned lock handle is intentional. Distributed locks
 usually need ownership data, such as a Redis token, to make unlock safe. If a
 job runs longer than the lock TTL, another worker may acquire the same key. A

--- a/middleware/distributednooverlapping/distributednooverlapping.go
+++ b/middleware/distributednooverlapping/distributednooverlapping.go
@@ -2,6 +2,7 @@ package distributednooverlapping
 
 import (
 	"context"
+	"errors"
 
 	"github.com/flc1125/go-cron/v4"
 )
@@ -55,9 +56,14 @@ func New(mu Mutex, opts ...Option) cron.Middleware {
 				o.logger.Info("skip job [%s], because distributed no overlapping", "mutex key", job.GetMutexKey())
 				return nil
 			}
+			if lock == nil {
+				err := errors.New("mutex acquired without lock")
+				o.logger.Error(err, "failed to lock mutex", "mutex key", job.GetMutexKey())
+				return err
+			}
 
 			defer func() {
-				if err := lock.Unlock(ctx); err != nil {
+				if err := lock.Unlock(context.WithoutCancel(ctx)); err != nil {
 					o.logger.Error(err, "failed to unlock mutex", "key", job.GetMutexKey())
 				}
 			}()

--- a/middleware/distributednooverlapping/distributednooverlapping.go
+++ b/middleware/distributednooverlapping/distributednooverlapping.go
@@ -53,7 +53,7 @@ func New(mu Mutex, opts ...Option) cron.Middleware {
 				return err
 			}
 			if !acquired {
-				o.logger.Info("skip job [%s], because distributed no overlapping", "mutex key", job.GetMutexKey())
+				o.logger.Info("skip job because distributed no overlapping", "mutex key", job.GetMutexKey())
 				return nil
 			}
 			if lock == nil {

--- a/middleware/distributednooverlapping/distributednooverlapping.go
+++ b/middleware/distributednooverlapping/distributednooverlapping.go
@@ -46,7 +46,7 @@ func New(mu Mutex, opts ...Option) cron.Middleware {
 				return original.Run(ctx)
 			}
 
-			acquired, err := o.mu.Lock(ctx, job)
+			lock, acquired, err := o.mu.Lock(ctx, job)
 			if err != nil {
 				o.logger.Error(err, "failed to lock mutex", "mutex key", job.GetMutexKey())
 				return err
@@ -57,7 +57,7 @@ func New(mu Mutex, opts ...Option) cron.Middleware {
 			}
 
 			defer func() {
-				if err := o.mu.Unlock(ctx, job); err != nil {
+				if err := lock.Unlock(ctx); err != nil {
 					o.logger.Error(err, "failed to unlock mutex", "key", job.GetMutexKey())
 				}
 			}()

--- a/middleware/distributednooverlapping/distributednooverlapping_test.go
+++ b/middleware/distributednooverlapping/distributednooverlapping_test.go
@@ -46,16 +46,12 @@ type testMutex struct {
 
 var _ Mutex = testMutex{}
 
-func (m testMutex) Lock(_ context.Context, job JobWithMutex) (bool, error) {
+func (m testMutex) Lock(_ context.Context, job JobWithMutex) (Lock, bool, error) {
 	if job.GetMutexKey() == "test" {
-		return true, nil
+		return noopLock{}, true, nil
 	}
 
-	return false, nil
-}
-
-func (m testMutex) Unlock(context.Context, JobWithMutex) error {
-	return nil
+	return nil, false, nil
 }
 
 func TestMiddleware_Noop(t *testing.T) {

--- a/middleware/distributednooverlapping/distributednooverlapping_test.go
+++ b/middleware/distributednooverlapping/distributednooverlapping_test.go
@@ -66,7 +66,7 @@ type contextCheckingMutex struct {
 }
 
 func (m contextCheckingMutex) Lock(context.Context, JobWithMutex) (Lock, bool, error) {
-	return contextCheckingLock{unlockErr: m.unlockErr}, true, nil
+	return contextCheckingLock(m), true, nil
 }
 
 type contextCheckingLock struct {

--- a/middleware/distributednooverlapping/distributednooverlapping_test.go
+++ b/middleware/distributednooverlapping/distributednooverlapping_test.go
@@ -3,6 +3,7 @@ package distributednooverlapping
 import (
 	"bytes"
 	"context"
+	"errors"
 	"log"
 	"sync"
 	"testing"
@@ -54,6 +55,29 @@ func (m testMutex) Lock(_ context.Context, job JobWithMutex) (Lock, bool, error)
 	return nil, false, nil
 }
 
+type nilLockMutex struct{}
+
+func (nilLockMutex) Lock(context.Context, JobWithMutex) (Lock, bool, error) {
+	return nil, true, nil
+}
+
+type contextCheckingMutex struct {
+	unlockErr chan<- error
+}
+
+func (m contextCheckingMutex) Lock(context.Context, JobWithMutex) (Lock, bool, error) {
+	return contextCheckingLock{unlockErr: m.unlockErr}, true, nil
+}
+
+type contextCheckingLock struct {
+	unlockErr chan<- error
+}
+
+func (l contextCheckingLock) Unlock(ctx context.Context) error {
+	l.unlockErr <- ctx.Err()
+	return nil
+}
+
 func TestMiddleware_Noop(t *testing.T) {
 	buf.Reset()
 
@@ -93,6 +117,52 @@ func TestMiddleware_Noop(t *testing.T) {
 	wg.Wait()
 	assert.Len(t, ch, 200)
 	assert.Empty(t, buf.String())
+}
+
+func TestMiddleware_NilAcquiredLock(t *testing.T) {
+	middleware := New(nilLockMutex{}, WithLogger(logger))
+	entry := entryForJob(testJob{
+		name: "test",
+		ttl:  time.Second,
+		Job: cron.JobFunc(func(context.Context) error {
+			return errors.New("job should not run")
+		}),
+	})
+
+	err := middleware(testJob{
+		name: "test",
+		ttl:  time.Second,
+		Job:  cron.NoopJob{},
+	}).Run(cron.WithEntryContext(ctx, &entry))
+	assert.EqualError(t, err, "mutex acquired without lock")
+}
+
+func TestMiddleware_UnlockWithoutCanceledContext(t *testing.T) {
+	unlockErr := make(chan error, 1)
+	middleware := New(contextCheckingMutex{unlockErr: unlockErr}, WithLogger(logger))
+	entry := entryForJob(testJob{
+		name: "test",
+		ttl:  time.Second,
+		Job:  cron.NoopJob{},
+	})
+	canceledCtx, cancel := context.WithCancel(ctx)
+
+	err := middleware(testJob{
+		name: "test",
+		ttl:  time.Second,
+		Job: cron.JobFunc(func(context.Context) error {
+			cancel()
+			return nil
+		}),
+	}).Run(cron.WithEntryContext(canceledCtx, &entry))
+	assert.NoError(t, err)
+	assert.NoError(t, <-unlockErr)
+}
+
+func entryForJob(job cron.Job) cron.Entry {
+	c := cron.New()
+	id := c.Schedule(cron.Every(time.Second), job)
+	return c.Entry(id)
 }
 
 // func TestMiddleware_Mutex(t *testing.T) {

--- a/middleware/distributednooverlapping/mutex.go
+++ b/middleware/distributednooverlapping/mutex.go
@@ -9,12 +9,15 @@ import (
 
 type Mutex interface {
 	// Lock tries to acquire the mutex for the job.
+	// If the mutex is acquired, it returns a lock that must be unlocked.
 	// If the mutex is acquired, it returns true.
 	// If the mutex is not acquired, it returns false.
-	Lock(ctx context.Context, job JobWithMutex) (bool, error)
+	Lock(ctx context.Context, job JobWithMutex) (Lock, bool, error)
+}
 
-	// Unlock releases the mutex for the job.
-	Unlock(ctx context.Context, job JobWithMutex) error
+type Lock interface {
+	// Unlock releases the acquired lock.
+	Unlock(ctx context.Context) error
 }
 
 type JobWithMutex interface {
@@ -30,10 +33,12 @@ type JobWithMutex interface {
 
 type NoopMutex struct{}
 
-func (m NoopMutex) Lock(context.Context, JobWithMutex) (bool, error) {
-	return true, nil
+func (m NoopMutex) Lock(context.Context, JobWithMutex) (Lock, bool, error) {
+	return noopLock{}, true, nil
 }
 
-func (m NoopMutex) Unlock(context.Context, JobWithMutex) error {
+type noopLock struct{}
+
+func (m noopLock) Unlock(context.Context) error {
 	return nil
 }

--- a/middleware/distributednooverlapping/mutex_test.go
+++ b/middleware/distributednooverlapping/mutex_test.go
@@ -10,10 +10,11 @@ func TestMutex_NoopMutex(t *testing.T) {
 	m := NoopMutex{}
 	ctx := t.Context()
 
-	acquired, err := m.Lock(ctx, nil)
+	lock, acquired, err := m.Lock(ctx, nil)
 	assert.NoError(t, err)
 	assert.True(t, acquired)
+	assert.NotNil(t, lock)
 
-	err = m.Unlock(ctx, nil)
+	err = lock.Unlock(ctx)
 	assert.NoError(t, err)
 }

--- a/middleware/distributednooverlapping/redismutex/mutex.go
+++ b/middleware/distributednooverlapping/redismutex/mutex.go
@@ -30,8 +30,6 @@ func WithPrefix(prefix string) Option {
 	}
 }
 
-var _ distributednooverlapping.Mutex = (*Mutex)(nil)
-
 var unlockScript = redis.NewScript(`
 if redis.call("GET", KEYS[1]) == ARGV[1] then
 	return redis.call("DEL", KEYS[1])

--- a/middleware/distributednooverlapping/redismutex/mutex.go
+++ b/middleware/distributednooverlapping/redismutex/mutex.go
@@ -2,6 +2,9 @@ package redismutex
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
 
 	"github.com/flc1125/go-cron/middleware/distributednooverlapping/v4"
 	redis "github.com/redis/go-redis/v9"
@@ -29,6 +32,13 @@ func WithPrefix(prefix string) Option {
 
 var _ distributednooverlapping.Mutex = (*Mutex)(nil)
 
+var unlockScript = redis.NewScript(`
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+	return redis.call("DEL", KEYS[1])
+end
+return 0
+`)
+
 func New(redis redis.UniversalClient, opts ...Option) *Mutex {
 	mutex := &Mutex{
 		redis:  redis,
@@ -40,10 +50,43 @@ func New(redis redis.UniversalClient, opts ...Option) *Mutex {
 	return mutex
 }
 
-func (m *Mutex) Lock(ctx context.Context, job distributednooverlapping.JobWithMutex) (bool, error) {
-	return m.redis.SetNX(ctx, m.prefix+job.GetMutexKey(), 1, job.GetMutexTTL()).Result()
+func (m *Mutex) Lock(ctx context.Context, job distributednooverlapping.JobWithMutex) (distributednooverlapping.Lock, bool, error) {
+	key := m.key(job)
+	token, err := newToken()
+	if err != nil {
+		return nil, false, err
+	}
+
+	acquired, err := m.redis.SetNX(ctx, key, token, job.GetMutexTTL()).Result()
+	if err != nil || !acquired {
+		return nil, acquired, err
+	}
+
+	return &lock{
+		redis: m.redis,
+		key:   key,
+		token: token,
+	}, true, nil
 }
 
-func (m *Mutex) Unlock(ctx context.Context, job distributednooverlapping.JobWithMutex) error {
-	return m.redis.Del(ctx, m.prefix+job.GetMutexKey()).Err()
+type lock struct {
+	redis redis.UniversalClient
+	key   string
+	token string
+}
+
+func (l *lock) Unlock(ctx context.Context) error {
+	return unlockScript.Run(ctx, l.redis, []string{l.key}, l.token).Err()
+}
+
+func newToken() (string, error) {
+	var token [32]byte
+	if _, err := rand.Read(token[:]); err != nil {
+		return "", fmt.Errorf("generate redis mutex token: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(token[:]), nil
+}
+
+func (m *Mutex) key(job distributednooverlapping.JobWithMutex) string {
+	return m.prefix + job.GetMutexKey()
 }

--- a/middleware/distributednooverlapping/redismutex/mutex_test.go
+++ b/middleware/distributednooverlapping/redismutex/mutex_test.go
@@ -177,11 +177,13 @@ func TestMutex_UnlockDoesNotDeleteSuccessorLock(t *testing.T) {
 	require.True(t, acquired)
 	require.NotNil(t, staleLock)
 
-	time.Sleep(staleJob.ttl + 25*time.Millisecond)
-
-	successorLock, acquired, err := successor.Lock(ctx, successorJob)
-	require.NoError(t, err)
-	require.True(t, acquired)
+	var successorLock distributednooverlapping.Lock
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		var err error
+		successorLock, acquired, err = successor.Lock(ctx, successorJob)
+		assert.NoError(collect, err)
+		assert.True(collect, acquired)
+	}, time.Second, 10*time.Millisecond)
 	require.NotNil(t, successorLock)
 
 	err = staleLock.Unlock(ctx)

--- a/middleware/distributednooverlapping/redismutex/mutex_test.go
+++ b/middleware/distributednooverlapping/redismutex/mutex_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/flc1125/go-cron/v4"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var ctx = context.Background()
@@ -59,25 +60,29 @@ func TestMutex(t *testing.T) {
 			ttl:  time.Second,
 		}
 
-		acquired, err := mutex.Lock(ctx, job)
+		lock, acquired, err := mutex.Lock(ctx, job)
 		assert.NoError(t, err)
 		assert.True(t, acquired)
+		assert.NotNil(t, lock)
 
-		acquired, err = mutex.Lock(ctx, job)
+		_, acquired, err = mutex.Lock(ctx, job)
 		assert.NoError(t, err)
 		assert.False(t, acquired)
 
-		time.Sleep(time.Second + time.Millisecond*10)
+		// unlock
+		err = lock.Unlock(ctx)
+		assert.NoError(t, err)
 
-		acquired, err = mutex.Lock(ctx, job)
+		lock, acquired, err = mutex.Lock(ctx, job)
 		assert.NoError(t, err)
 		assert.True(t, acquired)
+		assert.NotNil(t, lock)
 
 		// unlock
-		err = mutex.Unlock(ctx, job)
+		err = lock.Unlock(ctx)
 		assert.NoError(t, err)
 
-		acquired, err = mutex.Lock(ctx, job)
+		_, acquired, err = mutex.Lock(ctx, job)
 		assert.NoError(t, err)
 		assert.True(t, acquired)
 	})
@@ -102,43 +107,96 @@ func TestMutex(t *testing.T) {
 		}
 
 		// lock job1
-		acquired, err := mutex.Lock(ctx, job1)
+		lock1, acquired, err := mutex.Lock(ctx, job1)
 		assert.NoError(t, err)
 		assert.True(t, acquired)
+		assert.NotNil(t, lock1)
 
 		// lock job2
-		acquired, err = mutex.Lock(ctx, job2)
+		lock2, acquired, err := mutex.Lock(ctx, job2)
 		assert.NoError(t, err)
 		assert.True(t, acquired)
+		assert.NotNil(t, lock2)
 
-		acquired, err = mutex.Lock(ctx, job1)
+		_, acquired, err = mutex.Lock(ctx, job1)
 		assert.NoError(t, err)
 		assert.False(t, acquired)
 
-		acquired, err = mutex.Lock(ctx, job2)
+		_, acquired, err = mutex.Lock(ctx, job2)
 		assert.NoError(t, err)
 		assert.False(t, acquired)
 
 		// unlock job1
-		err = mutex.Unlock(ctx, job1)
+		err = lock1.Unlock(ctx)
 		assert.NoError(t, err)
 
-		acquired, err = mutex.Lock(ctx, job1)
+		lock1, acquired, err = mutex.Lock(ctx, job1)
 		assert.NoError(t, err)
 		assert.True(t, acquired)
+		assert.NotNil(t, lock1)
+
+		// unlock job1
+		err = lock1.Unlock(ctx)
+		assert.NoError(t, err)
 
 		// unlock job2
-		err = mutex.Unlock(ctx, job1)
+		err = lock2.Unlock(ctx)
 		assert.NoError(t, err)
 
-		// unlock
-		err = mutex.Unlock(ctx, job2)
-		assert.NoError(t, err)
-
-		acquired, err = mutex.Lock(ctx, job2)
+		_, acquired, err = mutex.Lock(ctx, job2)
 		assert.NoError(t, err)
 		assert.True(t, acquired)
 	})
+}
+
+func TestMutex_UnlockDoesNotDeleteSuccessorLock(t *testing.T) {
+	client := createRedis(t)
+	staleOwner := New(client, WithPrefix("test:cron"))
+	successor := New(client, WithPrefix("test:cron"))
+	contender := New(client, WithPrefix("test:cron"))
+
+	staleJob := testJob{
+		t: t,
+		job: func(context.Context) error {
+			return nil
+		},
+		name: "job:stale-owner",
+		ttl:  50 * time.Millisecond,
+	}
+	successorJob := testJob{
+		t: t,
+		job: func(context.Context) error {
+			return nil
+		},
+		name: staleJob.name,
+		ttl:  time.Second,
+	}
+
+	staleLock, acquired, err := staleOwner.Lock(ctx, staleJob)
+	require.NoError(t, err)
+	require.True(t, acquired)
+	require.NotNil(t, staleLock)
+
+	time.Sleep(staleJob.ttl + 25*time.Millisecond)
+
+	successorLock, acquired, err := successor.Lock(ctx, successorJob)
+	require.NoError(t, err)
+	require.True(t, acquired)
+	require.NotNil(t, successorLock)
+
+	err = staleLock.Unlock(ctx)
+	require.NoError(t, err)
+
+	_, acquired, err = contender.Lock(ctx, successorJob)
+	require.NoError(t, err)
+	assert.False(t, acquired, "stale unlock must not remove the successor lock")
+
+	err = successorLock.Unlock(ctx)
+	require.NoError(t, err)
+
+	_, acquired, err = contender.Lock(ctx, successorJob)
+	require.NoError(t, err)
+	assert.True(t, acquired)
 }
 
 func TestMutex_Prefix(t *testing.T) {


### PR DESCRIPTION
## Summary
Fix Redis distributed no-overlap unlock safety by binding unlock ownership to the acquired lock handle instead of unlocking by mutex key alone.

## Changes
- Change distributednooverlapping.Mutex.Lock to return a Lock handle
- Move unlock behavior onto the returned Lock handle
- Add Redis owner tokens and atomic compare-and-delete unlock logic
- Harden middleware cleanup by unlocking with context.WithoutCancel and rejecting nil acquired locks
- Update README guidance for custom mutex implementations

## Motivation
- The previous Redis mutex could delete a successor owner's lock when an old job exceeded its TTL and later called Unlock
- Binding unlock to the acquired handle preserves ownership across TTL expiry and prevents stale-owner unlocks from clearing newer locks

## Breaking Changes
- Custom distributednooverlapping.Mutex implementations must return a Lock handle from Lock
- The previous Unlock(ctx, job) method on Mutex is removed
- Users only constructing the built-in Redis mutex with redismutex.New(...) generally do not need call-site changes
- Users with custom mutex implementations need to move unlock state into the returned Lock handle

## Testing
- go test ./... in middleware/distributednooverlapping
- go test ./... in middleware/distributednooverlapping/redismutex
- go test ./... at repository root

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent operations when a lock is acquired but returns a nil handle.
  * Improved lock ownership binding using token-based validation during release to prevent accidental unlocks.
  * Enhanced unlock behavior to use non-canceled contexts ensuring safe cleanup.

* **Documentation**
  * Updated documentation with Custom Mutex interface requirements and safe unlock behavior guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->