### PR TITLE
docs(delayoverlapping): document queued run behavior

### DIFF
--- a/middleware/delayoverlapping/README.md
+++ b/middleware/delayoverlapping/README.md
@@ -1,10 +1,26 @@
 # Delay Overlapping Middleware
 
-This middleware is used to delay the overlapping of the cron job. 
+This middleware is used to delay overlapping cron job runs.
 
 If the previous job is not finished, the next job will be delayed until the previous job is finished.
 
 If the previous job greater than the reminder time, the logger will print the info message.
+
+## Behavior
+
+`delayoverlapping` serializes overlapping runs of the same job with an in-memory mutex.
+It does not skip overlapping runs. Instead, each overlapping run waits for the previous
+run to finish and then executes.
+
+This means high-frequency schedules combined with long-running jobs can create a backlog
+of waiting goroutines. Use this middleware when every scheduled run should eventually
+execute in order.
+
+If overlapping runs should be skipped instead of queued, use
+[`nooverlapping`](../nooverlapping).
+
+`WithReminderTime` controls when a delayed run is logged as slow. It does not set a job
+timeout, cancel waiting runs, or limit the backlog size.
 
 ## Usage
 

--- a/middleware/delayoverlapping/README.md
+++ b/middleware/delayoverlapping/README.md
@@ -4,7 +4,7 @@ This middleware is used to delay overlapping cron job runs.
 
 If the previous job is not finished, the next job will be delayed until the previous job is finished.
 
-If the previous job greater than the reminder time, the logger will print the info message.
+If a job execution takes longer than the reminder time, the logger will print an info message.
 
 ## Behavior
 
@@ -13,13 +13,14 @@ It does not skip overlapping runs. Instead, each overlapping run waits for the p
 run to finish and then executes.
 
 This means high-frequency schedules combined with long-running jobs can create a backlog
-of waiting goroutines. Use this middleware when every scheduled run should eventually
-execute in order.
+of waiting goroutines. Use this middleware when, during normal in-process operation,
+each scheduled run should wait and execute sequentially instead of being skipped.
 
 If overlapping runs should be skipped instead of queued, use
 [`nooverlapping`](../nooverlapping).
 
-`WithReminderTime` controls when a delayed run is logged as slow. It does not set a job
+`WithReminderTime` controls when a job execution duration is logged after the job
+finishes. Time spent waiting for the mutex is not included. It does not set a job
 timeout, cancel waiting runs, or limit the backlog size.
 
 ## Usage


### PR DESCRIPTION
## Summary
Document the queue/backlog semantics of the delayoverlapping middleware.

## Changes
- Clarify that overlapping runs wait and eventually execute instead of being skipped
- Document that high-frequency schedules with long-running jobs can accumulate waiting goroutines
- Point users to nooverlapping when they want overlapping runs to be skipped
- Clarify that WithReminderTime controls logging only, not timeout, cancellation, or backlog limits

## Motivation
- The existing README described delayed execution but did not make the queue/backlog behavior explicit enough for users choosing between delayoverlapping and nooverlapping

## Testing
- go test ./... in middleware/delayoverlapping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced delayoverlapping middleware documentation with clearer behavior descriptions, including details on how overlapping runs are handled via serialization, backlog implications for high-frequency schedules, and clarification on the WithReminderTime configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->