### PR TITLE
fix(parser): reject incomplete timezone prefixes

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 )
 
 // ParseOption Configuration options for creating a parser. Most options specify which
@@ -91,14 +92,16 @@ func (p Parser) Parse(spec string) (Schedule, error) {
 
 	// Extract timezone if present
 	loc := time.Local
-	if strings.HasPrefix(spec, "TZ=") || strings.HasPrefix(spec, "CRON_TZ=") {
+	if prefix := timezonePrefix(spec); prefix != "" {
 		var err error
-		i := strings.Index(spec, " ")
-		eq := strings.Index(spec, "=")
-		if loc, err = time.LoadLocation(spec[eq+1 : i]); err != nil {
-			return nil, fmt.Errorf("provided bad location %s: %v", spec[eq+1:i], err)
+		timezone, schedule, err := extractTimezone(spec, prefix)
+		if err != nil {
+			return nil, err
 		}
-		spec = strings.TrimSpace(spec[i:])
+		if loc, err = time.LoadLocation(timezone); err != nil {
+			return nil, fmt.Errorf("provided bad location %s: %v", timezone, err)
+		}
+		spec = schedule
 	}
 
 	// Handle named schedules (descriptors), if configured
@@ -149,6 +152,37 @@ func (p Parser) Parse(spec string) (Schedule, error) {
 		Dow:      dayofweek,
 		Location: loc,
 	}, nil
+}
+
+func timezonePrefix(spec string) string {
+	switch {
+	case strings.HasPrefix(spec, "CRON_TZ="):
+		return "CRON_TZ="
+	case strings.HasPrefix(spec, "TZ="):
+		return "TZ="
+	default:
+		return ""
+	}
+}
+
+func extractTimezone(spec, prefix string) (timezone, schedule string, err error) {
+	rest := spec[len(prefix):]
+	i := strings.IndexFunc(rest, unicode.IsSpace)
+	if i < 0 {
+		return "", "", fmt.Errorf("missing schedule after timezone: %s", spec)
+	}
+
+	timezone = rest[:i]
+	if timezone == "" {
+		return "", "", fmt.Errorf("missing timezone in spec: %s", spec)
+	}
+
+	schedule = strings.TrimSpace(rest[i:])
+	if schedule == "" {
+		return "", "", fmt.Errorf("missing schedule after timezone: %s", spec)
+	}
+
+	return timezone, schedule, nil
 }
 
 // normalizeFields takes a subset set of the time fields and returns the full set

--- a/parser.go
+++ b/parser.go
@@ -168,6 +168,10 @@ func timezonePrefix(spec string) string {
 
 func extractTimezone(spec, prefix string) (timezone, schedule string, err error) {
 	rest := spec[len(prefix):]
+	if rest == "" {
+		return "", "", fmt.Errorf("missing timezone in spec: %s", spec)
+	}
+
 	i := strings.IndexFunc(rest, unicode.IsSpace)
 	if i < 0 {
 		return "", "", fmt.Errorf("missing schedule after timezone: %s", spec)

--- a/parser.go
+++ b/parser.go
@@ -93,14 +93,15 @@ func (p Parser) Parse(spec string) (Schedule, error) {
 	// Extract timezone if present
 	loc := time.Local
 	if prefix := timezonePrefix(spec); prefix != "" {
-		var err error
 		timezone, schedule, err := extractTimezone(spec, prefix)
 		if err != nil {
 			return nil, err
 		}
-		if loc, err = time.LoadLocation(timezone); err != nil {
+		loadedLocation, err := time.LoadLocation(timezone)
+		if err != nil {
 			return nil, fmt.Errorf("provided bad location %s: %v", timezone, err)
 		}
+		loc = loadedLocation
 		spec = schedule
 	}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -125,6 +125,10 @@ func TestParseScheduleErrors(t *testing.T) {
 		{"@unrecognized", "unrecognized descriptor"},
 		{"* * * *", "expected 5 to 6 fields"},
 		{"", "empty spec string"},
+		{"TZ=UTC", "missing schedule after timezone"},
+		{"CRON_TZ=UTC", "missing schedule after timezone"},
+		{"TZ= * * * * *", "missing timezone"},
+		{"CRON_TZ= * * * * *", "missing timezone"},
 	}
 	for _, c := range tests {
 		actual, err := secondParser.Parse(c.expr)
@@ -149,6 +153,7 @@ func TestParseSchedule(t *testing.T) {
 		{secondParser, "CRON_TZ=UTC  0 5 * * * *", every5min(time.UTC)},
 		{standardParser, "CRON_TZ=UTC  5 * * * *", every5min(time.UTC)},
 		{secondParser, "CRON_TZ=Asia/Tokyo 0 5 * * * *", every5min(tokyo)},
+		{secondParser, "CRON_TZ=UTC\t0 5 * * * *", every5min(time.UTC)},
 		{secondParser, "@every 5m", ConstantDelaySchedule{5 * time.Minute}},
 		{secondParser, "@midnight", midnight(time.Local)},
 		{secondParser, "TZ=UTC  @midnight", midnight(time.UTC)},

--- a/parser_test.go
+++ b/parser_test.go
@@ -125,6 +125,8 @@ func TestParseScheduleErrors(t *testing.T) {
 		{"@unrecognized", "unrecognized descriptor"},
 		{"* * * *", "expected 5 to 6 fields"},
 		{"", "empty spec string"},
+		{"TZ=", "missing timezone"},
+		{"CRON_TZ=", "missing timezone"},
 		{"TZ=UTC", "missing schedule after timezone"},
 		{"CRON_TZ=UTC", "missing schedule after timezone"},
 		{"TZ=UTC ", "missing schedule after timezone"},

--- a/parser_test.go
+++ b/parser_test.go
@@ -127,8 +127,11 @@ func TestParseScheduleErrors(t *testing.T) {
 		{"", "empty spec string"},
 		{"TZ=UTC", "missing schedule after timezone"},
 		{"CRON_TZ=UTC", "missing schedule after timezone"},
+		{"TZ=UTC ", "missing schedule after timezone"},
+		{"CRON_TZ=UTC\t", "missing schedule after timezone"},
 		{"TZ= * * * * *", "missing timezone"},
 		{"CRON_TZ= * * * * *", "missing timezone"},
+		{"TZ=Unknown/Nowhere * * * * *", "provided bad location Unknown/Nowhere"},
 	}
 	for _, c := range tests {
 		actual, err := secondParser.Parse(c.expr)


### PR DESCRIPTION
## Summary
Fix parser handling for incomplete timezone prefixes so malformed TZ and CRON_TZ inputs return errors instead of panicking.

## Changes
- Validate timezone prefixes before slicing the input string
- Return parse errors for timezone prefixes without a following schedule
- Return parse errors for empty timezone names
- Keep valid TZ and CRON_TZ schedules working, including whitespace-separated inputs

## Motivation
- Inputs like TZ=UTC and CRON_TZ=UTC previously panicked due to slicing with a missing separator index

## Testing
- go test -run 'TestParseSchedule(Errors)?$' ./...
- go test ./...