### PR TITLE
ci: fix codecov coverage paths

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,16 @@
-coverage:
+codecov:
   require_ci_to_pass: true
 
+fixes:
+  - "github.com/flc1125/go-cron/v4/::"
+  - "github.com/flc1125/go-cron/middleware/delayoverlapping/v4/::middleware/delayoverlapping/"
+  - "github.com/flc1125/go-cron/middleware/distributednooverlapping/v4/::middleware/distributednooverlapping/"
+  - "github.com/flc1125/go-cron/middleware/distributednooverlapping/redismutex/v4/::middleware/distributednooverlapping/redismutex/"
+  - "github.com/flc1125/go-cron/middleware/nooverlapping/v4/::middleware/nooverlapping/"
+  - "github.com/flc1125/go-cron/middleware/otel/v4/::middleware/otel/"
+  - "github.com/flc1125/go-cron/middleware/recovery/v4/::middleware/recovery/"
+
+coverage:
   status:
     project:
       default:


### PR DESCRIPTION
## Summary
Fix Codecov coverage path resolution for the multi-module repository by adding module import path mappings.

## Changes
- Move `require_ci_to_pass` under the top-level `codecov` key
- Add Codecov `fixes` entries for the root module and middleware modules

## Motivation
- Codecov coverage profiles use Go module import paths, so the uploaded coverage needs explicit mappings back to repository paths

## Testing
- `ruby -ryaml -e 'cfg = YAML.load_file("codecov.yml"); abort("missing codecov.require_ci_to_pass") unless cfg.dig("codecov", "require_ci_to_pass") == true; abort("unexpected fixes count") unless cfg["fixes"].is_a?(Array) && cfg["fixes"].size == 7; puts "codecov.yml OK: #{cfg["fixes"].size} fixes"'`
- `GOCACHE=/private/tmp/go-cron-gocache GOTMPDIR=/private/tmp/go-cron-gotmp make test-coverage`
