### PR TITLE
ci: upload codecov coverage file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,9 @@ jobs:
         run: make test-coverage
 
       - name: Upload coverage to Codecov
+        if: matrix.go-version == '1.26.x' && matrix.platform == 'ubuntu-latest'
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.txt
+          disable_search: true


### PR DESCRIPTION
## Summary
Align the Codecov upload step with the tested coverage artifact produced by `make test-coverage`.

## Changes
- Upload coverage only from the `1.26.x` Ubuntu matrix job
- Explicitly upload `coverage.txt`
- Disable Codecov's automatic coverage file search

## Motivation
- The workflow should upload the merged coverage report generated by the test target instead of relying on Codecov auto-discovery across matrix jobs.

## Testing
- `ruby -ryaml -e 'cfg = YAML.load_file(".github/workflows/test.yml"); step = cfg.dig("jobs", "test", "steps").find { |s| s["name"] == "Upload coverage to Codecov" }; abort("missing upload step") unless step; abort("missing if") unless step["if"] == "matrix.go-version == '\''1.26.x'\'' && matrix.platform == '\''ubuntu-latest'\''"; abort("missing files") unless step.dig("with", "files") == "coverage.txt"; abort("missing disable_search") unless step.dig("with", "disable_search") == true; puts "test.yml OK"'`
