### PR TITLE
test(distributednooverlapping): cover middleware branches

### DIFF
--- a/middleware/distributednooverlapping/distributednooverlapping_test.go
+++ b/middleware/distributednooverlapping/distributednooverlapping_test.go
@@ -78,6 +78,49 @@ func (l contextCheckingLock) Unlock(ctx context.Context) error {
 	return nil
 }
 
+type spyMutex struct {
+	lock     Lock
+	acquired bool
+	err      error
+
+	lockCalls int
+	job       JobWithMutex
+}
+
+func (m *spyMutex) Lock(_ context.Context, job JobWithMutex) (Lock, bool, error) {
+	m.lockCalls++
+	m.job = job
+	return m.lock, m.acquired, m.err
+}
+
+type spyLock struct {
+	err         error
+	unlockCalls int
+}
+
+func (l *spyLock) Unlock(context.Context) error {
+	l.unlockCalls++
+	return l.err
+}
+
+type logCall struct {
+	err error
+	msg string
+}
+
+type spyLogger struct {
+	infos  []logCall
+	errors []logCall
+}
+
+func (l *spyLogger) Info(msg string, _ ...any) {
+	l.infos = append(l.infos, logCall{msg: msg})
+}
+
+func (l *spyLogger) Error(err error, msg string, _ ...any) {
+	l.errors = append(l.errors, logCall{err: err, msg: msg})
+}
+
 func TestMiddleware_Noop(t *testing.T) {
 	buf.Reset()
 
@@ -119,6 +162,84 @@ func TestMiddleware_Noop(t *testing.T) {
 	assert.Empty(t, buf.String())
 }
 
+func TestMiddleware_NoEntryContextRunsOriginalJob(t *testing.T) {
+	mutex := &spyMutex{}
+	middleware := New(mutex)
+	ran := false
+
+	err := middleware(cron.JobFunc(func(context.Context) error {
+		ran = true
+		return nil
+	})).Run(ctx)
+
+	assert.NoError(t, err)
+	assert.True(t, ran)
+	assert.Zero(t, mutex.lockCalls)
+}
+
+func TestMiddleware_NonMutexEntryJobRunsOriginalJob(t *testing.T) {
+	mutex := &spyMutex{}
+	middleware := New(mutex)
+	entry := entryForJob(cron.NoopJob{})
+	ran := false
+
+	err := middleware(cron.JobFunc(func(context.Context) error {
+		ran = true
+		return nil
+	})).Run(cron.WithEntryContext(ctx, &entry))
+
+	assert.NoError(t, err)
+	assert.True(t, ran)
+	assert.Zero(t, mutex.lockCalls)
+}
+
+func TestMiddleware_LockErrorReturnsError(t *testing.T) {
+	lockErr := errors.New("lock failed")
+	mutex := &spyMutex{err: lockErr}
+	logger := &spyLogger{}
+	middleware := New(mutex, WithLogger(logger))
+	entry := entryForJob(testJob{
+		name: "test",
+		ttl:  time.Second,
+		Job:  cron.NoopJob{},
+	})
+	ran := false
+
+	err := middleware(cron.JobFunc(func(context.Context) error {
+		ran = true
+		return nil
+	})).Run(cron.WithEntryContext(ctx, &entry))
+
+	assert.ErrorIs(t, err, lockErr)
+	assert.False(t, ran)
+	assert.Equal(t, 1, mutex.lockCalls)
+	assert.Equal(t, "test", mutex.job.GetMutexKey())
+	assert.Len(t, logger.errors, 1)
+	assert.ErrorIs(t, logger.errors[0].err, lockErr)
+}
+
+func TestMiddleware_UnacquiredLockSkipsJob(t *testing.T) {
+	mutex := &spyMutex{acquired: false}
+	logger := &spyLogger{}
+	middleware := New(mutex, WithLogger(logger))
+	entry := entryForJob(testJob{
+		name: "test",
+		ttl:  time.Second,
+		Job:  cron.NoopJob{},
+	})
+	ran := false
+
+	err := middleware(cron.JobFunc(func(context.Context) error {
+		ran = true
+		return nil
+	})).Run(cron.WithEntryContext(ctx, &entry))
+
+	assert.NoError(t, err)
+	assert.False(t, ran)
+	assert.Equal(t, 1, mutex.lockCalls)
+	assert.Len(t, logger.infos, 1)
+}
+
 func TestMiddleware_NilAcquiredLock(t *testing.T) {
 	middleware := New(nilLockMutex{}, WithLogger(logger))
 	entry := entryForJob(testJob{
@@ -135,6 +256,51 @@ func TestMiddleware_NilAcquiredLock(t *testing.T) {
 		Job:  cron.NoopJob{},
 	}).Run(cron.WithEntryContext(ctx, &entry))
 	assert.EqualError(t, err, "mutex acquired without lock")
+}
+
+func TestMiddleware_SuccessfulJobUnlocks(t *testing.T) {
+	lock := &spyLock{}
+	mutex := &spyMutex{lock: lock, acquired: true}
+	middleware := New(mutex)
+	entry := entryForJob(testJob{
+		name: "test",
+		ttl:  time.Second,
+		Job:  cron.NoopJob{},
+	})
+	ran := false
+
+	err := middleware(cron.JobFunc(func(context.Context) error {
+		ran = true
+		return nil
+	})).Run(cron.WithEntryContext(ctx, &entry))
+
+	assert.NoError(t, err)
+	assert.True(t, ran)
+	assert.Equal(t, 1, mutex.lockCalls)
+	assert.Equal(t, 1, lock.unlockCalls)
+}
+
+func TestMiddleware_UnlockErrorDoesNotOverrideJobError(t *testing.T) {
+	jobErr := errors.New("job failed")
+	unlockErr := errors.New("unlock failed")
+	lock := &spyLock{err: unlockErr}
+	mutex := &spyMutex{lock: lock, acquired: true}
+	logger := &spyLogger{}
+	middleware := New(mutex, WithLogger(logger))
+	entry := entryForJob(testJob{
+		name: "test",
+		ttl:  time.Second,
+		Job:  cron.NoopJob{},
+	})
+
+	err := middleware(cron.JobFunc(func(context.Context) error {
+		return jobErr
+	})).Run(cron.WithEntryContext(ctx, &entry))
+
+	assert.ErrorIs(t, err, jobErr)
+	assert.Equal(t, 1, lock.unlockCalls)
+	assert.Len(t, logger.errors, 1)
+	assert.ErrorIs(t, logger.errors[0].err, unlockErr)
 }
 
 func TestMiddleware_UnlockWithoutCanceledContext(t *testing.T) {


### PR DESCRIPTION
## Summary
Add focused tests for the distributed no-overlapping middleware branches.

## Changes
- Cover pass-through behavior when no cron entry is present or the entry job does not implement `JobWithMutex`
- Cover lock error, skipped lock acquisition, nil acquired lock, successful unlock, and unlock error handling
- Use lightweight fake mutex, lock, and logger implementations to drive middleware behavior directly

## Motivation
- This is phase 1 of the package-level coverage plan and raises `middleware/distributednooverlapping` coverage from 81.2% to 100.0%.

## Testing
- `GOCACHE=/private/tmp/go-cron-gocache GOTMPDIR=/private/tmp/go-cron-gotmp go test ./...` from `middleware/distributednooverlapping`
- `GOCACHE=/private/tmp/go-cron-gocache GOTMPDIR=/private/tmp/go-cron-gotmp go test -coverpkg=./... -covermode=atomic -coverprofile=coverage.out ./...` from `middleware/distributednooverlapping`
- `GOCACHE=/private/tmp/go-cron-gocache GOTMPDIR=/private/tmp/go-cron-gotmp make test-coverage`
