### PR TITLE
test(otel): cover middleware branches

### DIFF
--- a/middleware/otel/metrics_test.go
+++ b/middleware/otel/metrics_test.go
@@ -1,12 +1,32 @@
 package otel
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/noop"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 )
+
+type failingMeter struct {
+	noop.Meter
+}
+
+var errInstrument = errors.New("instrument failed")
+
+func (failingMeter) Int64Counter(string, ...metric.Int64CounterOption) (metric.Int64Counter, error) {
+	return noop.Int64Counter{}, errInstrument
+}
+
+func (failingMeter) Int64UpDownCounter(string, ...metric.Int64UpDownCounterOption) (metric.Int64UpDownCounter, error) {
+	return noop.Int64UpDownCounter{}, errInstrument
+}
+
+func (failingMeter) Float64Histogram(string, ...metric.Float64HistogramOption) (metric.Float64Histogram, error) {
+	return noop.Float64Histogram{}, errInstrument
+}
 
 func TestMetrics_newMetrics(t *testing.T) {
 	t.Run("noop meter", func(t *testing.T) {
@@ -34,5 +54,13 @@ func TestMetrics_newMetrics(t *testing.T) {
 		assert.NotEqual(t, noop.Int64Counter{}, m.counter)
 		assert.NotEqual(t, noop.Int64UpDownCounter{}, m.inflight)
 		assert.NotEqual(t, noop.Float64Histogram{}, m.duration)
+	})
+
+	t.Run("instrument errors", func(t *testing.T) {
+		m := newMetrics(failingMeter{})
+		assert.NotNil(t, m)
+		assert.Equal(t, noop.Int64Counter{}, m.counter)
+		assert.Equal(t, noop.Int64UpDownCounter{}, m.inflight)
+		assert.Equal(t, noop.Float64Histogram{}, m.duration)
 	})
 }

--- a/middleware/otel/otel_test.go
+++ b/middleware/otel/otel_test.go
@@ -3,6 +3,7 @@ package otel
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/flc1125/go-cron/v4"
 	"github.com/stretchr/testify/assert"
@@ -92,13 +93,30 @@ func TestTracing(t *testing.T) {
 	}
 }
 
-func TestTracing_NotJobWithName(t *testing.T) {
-	defer imsb.Reset()
+func TestTracing_PassThroughWithoutNamedEntryJob(t *testing.T) {
+	tests := []struct {
+		name     string
+		entryJob cron.Job
+	}{
+		{name: "no entry context"},
+		{name: "entry job without name", entryJob: cron.NoopJob{}},
+	}
 
-	require.NoError(t, middleware(cron.JobFunc(func(context.Context) error {
-		return nil
-	})).Run(ctx))
-	require.Len(t, imsb.GetSpans(), 0)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer imsb.Reset()
+			runCtx := ctx
+			if tt.entryJob != nil {
+				entry := entryForJob(tt.entryJob)
+				runCtx = cron.WithEntryContext(ctx, &entry)
+			}
+
+			require.NoError(t, middleware(cron.JobFunc(func(context.Context) error {
+				return nil
+			})).Run(runCtx))
+			require.Len(t, imsb.GetSpans(), 0)
+		})
+	}
 }
 
 func TestMetrics(t *testing.T) {
@@ -189,4 +207,10 @@ func TestMetrics(t *testing.T) {
 			},
 		},
 	}, rm.ScopeMetrics[0].Metrics[2], metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
+}
+
+func entryForJob(job cron.Job) cron.Entry {
+	c := cron.New()
+	id := c.Schedule(cron.Every(time.Second), job)
+	return c.Entry(id)
 }


### PR DESCRIPTION
## Summary
Add focused tests for the OpenTelemetry middleware coverage gaps.

## Changes
- Cover pass-through behavior when no cron entry is present or the entry job does not implement `JobWithName`
- Cover metric instrument creation failures with a small fake meter and verify noop fallback instruments are used

## Motivation
- This is phase 2 of the package-level coverage plan and raises `middleware/otel` coverage from 86.9% to 100.0%.

## Testing
- `GOCACHE=/private/tmp/go-cron-gocache GOTMPDIR=/private/tmp/go-cron-gotmp go test ./...` from `middleware/otel`
- `GOCACHE=/private/tmp/go-cron-gocache GOTMPDIR=/private/tmp/go-cron-gotmp go test -coverpkg=./... -covermode=atomic -coverprofile=coverage.out ./...` from `middleware/otel`
- `GOCACHE=/private/tmp/go-cron-gocache GOTMPDIR=/private/tmp/go-cron-gotmp make test-coverage`
