### PR TITLE
test: migrate assertions to testify

### DIFF
--- a/cron_test.go
+++ b/cron_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Many tests schedule a job for every second, and then wait at most a second
@@ -45,7 +46,7 @@ func TestNoEntries(t *testing.T) {
 
 	select {
 	case <-time.After(OneSecond):
-		t.Fatal("expected cron will be stopped immediately")
+		require.FailNow(t, "expected cron will be stopped immediately")
 	case <-stop(cron):
 	}
 }
@@ -67,7 +68,7 @@ func TestStopCausesJobsToNotRun(t *testing.T) {
 	case <-time.After(OneSecond):
 		// No job ran!
 	case <-wait(wg):
-		t.Fatal("expected stopped cron does not run any job")
+		require.FailNow(t, "expected stopped cron does not run any job")
 	}
 }
 
@@ -87,7 +88,7 @@ func TestAddBeforeRunning(t *testing.T) {
 	// Give cron 2 seconds to run our job (which is always activated).
 	select {
 	case <-time.After(OneSecond):
-		t.Fatal("expected job runs")
+		require.FailNow(t, "expected job runs")
 	case <-wait(wg):
 	}
 }
@@ -107,7 +108,7 @@ func TestAddWhileRunning(t *testing.T) {
 
 	select {
 	case <-time.After(OneSecond):
-		t.Fatal("expected job runs")
+		require.FailNow(t, "expected job runs")
 	case <-wait(wg):
 	}
 }
@@ -125,9 +126,7 @@ func TestAddWhileRunningWithDelay(t *testing.T) {
 	})
 
 	<-time.After(OneSecond)
-	if atomic.LoadInt64(&calls) != 1 {
-		t.Errorf("called %d times, expected 1\n", calls)
-	}
+	assert.Equal(t, int64(1), atomic.LoadInt64(&calls))
 }
 
 // Add a job, remove a job, start cron, expect nothing runs.
@@ -148,7 +147,7 @@ func TestRemoveBeforeRunning(t *testing.T) {
 	case <-time.After(OneSecond):
 		// Success, shouldn't run
 	case <-wait(wg):
-		t.FailNow()
+		require.FailNow(t, "expected removed job not to run")
 	}
 }
 
@@ -169,7 +168,7 @@ func TestRemoveWhileRunning(t *testing.T) {
 	select {
 	case <-time.After(OneSecond):
 	case <-wait(wg):
-		t.FailNow()
+		require.FailNow(t, "expected removed job not to run")
 	}
 }
 
@@ -193,7 +192,7 @@ func TestSnapshotEntries(t *testing.T) {
 	// Even though Entries was called, the cron should fire at the 2 second mark.
 	select {
 	case <-time.After(OneSecond):
-		t.Error("expected job runs at 2 second mark")
+		assert.Fail(t, "expected job runs at 2 second mark")
 	case <-wait(wg):
 	}
 }
@@ -213,11 +212,11 @@ func TestMultipleEntries(t *testing.T) {
 		return nil
 	})
 	id1, _ := cron.AddFunc("* * * * * ?", func(context.Context) error {
-		t.Fatal()
+		assert.Fail(t, "removed job should not run")
 		return nil
 	})
 	id2, _ := cron.AddFunc("* * * * * ?", func(context.Context) error {
-		t.Fatal()
+		assert.Fail(t, "removed job should not run")
 		return nil
 	})
 	_, _ = cron.AddFunc("0 0 0 31 12 ?", func(context.Context) error { return nil })
@@ -233,7 +232,7 @@ func TestMultipleEntries(t *testing.T) {
 
 	select {
 	case <-time.After(OneSecond):
-		t.Error("expected job run in proper order")
+		assert.Fail(t, "expected job run in proper order")
 	case <-wait(wg):
 	}
 }
@@ -256,7 +255,7 @@ func TestRunningJobTwice(t *testing.T) {
 
 	select {
 	case <-time.After(2 * OneSecond):
-		t.Error("expected job fires 2 times")
+		assert.Fail(t, "expected job fires 2 times")
 	case <-wait(wg):
 	}
 }
@@ -284,7 +283,7 @@ func TestRunningMultipleSchedules(t *testing.T) {
 
 	select {
 	case <-time.After(2 * OneSecond):
-		t.Error("expected job fires 2 times")
+		assert.Fail(t, "expected job fires 2 times")
 	case <-wait(wg):
 	}
 }
@@ -392,7 +391,7 @@ func TestLocalTimezone(t *testing.T) {
 
 	select {
 	case <-time.After(OneSecond * 2):
-		t.Error("expected job fires 2 times")
+		assert.Fail(t, "expected job fires 2 times")
 	case <-wait(wg):
 	}
 }
@@ -403,10 +402,7 @@ func TestNonLocalTimezone(t *testing.T) {
 	wg.Add(2)
 
 	loc, err := time.LoadLocation("Atlantic/Cape_Verde")
-	if err != nil {
-		fmt.Printf("Failed to load time zone Atlantic/Cape_Verde: %+v", err)
-		t.Fail()
-	}
+	require.NoError(t, err, "Failed to load time zone Atlantic/Cape_Verde")
 
 	now := time.Now().In(loc)
 	// FIX: Issue #205
@@ -429,7 +425,7 @@ func TestNonLocalTimezone(t *testing.T) {
 
 	select {
 	case <-time.After(OneSecond * 2):
-		t.Error("expected job fires 2 times")
+		assert.Fail(t, "expected job fires 2 times")
 	case <-wait(wg):
 	}
 }
@@ -455,9 +451,7 @@ func (t testJob) Run(context.Context) error {
 func TestInvalidJobSpec(t *testing.T) {
 	cron := New()
 	_, err := cron.AddJob("this will not parse", nil)
-	if err == nil {
-		t.Errorf("expected an error with invalid spec, got nil")
-	}
+	assert.Error(t, err, "expected an error with invalid spec, got nil")
 }
 
 // Test blocking run method behaves as Start()
@@ -481,9 +475,9 @@ func TestBlockingRun(t *testing.T) {
 
 	select {
 	case <-time.After(OneSecond):
-		t.Error("expected job fires")
+		assert.Fail(t, "expected job fires")
 	case <-unblockChan:
-		t.Error("expected that Run() blocks")
+		assert.Fail(t, "expected that Run() blocks")
 	case <-wait(wg):
 	}
 }
@@ -512,7 +506,7 @@ func TestStartNoop(t *testing.T) {
 	select {
 	case <-time.After(time.Millisecond):
 	case <-tickChan:
-		t.Error("expected job fires exactly twice")
+		assert.Fail(t, "expected job fires exactly twice")
 	}
 }
 
@@ -530,19 +524,15 @@ func TestJob(t *testing.T) {
 	job5 := cron.Schedule(Every(5*time.Minute), testJob{wg, "job5"})
 
 	// Test getting an Entry pre-Start.
-	if actualName := cron.Entry(job2).job.(testJob).name; actualName != "job2" {
-		t.Error("wrong job retrieved:", actualName)
-	}
-	if actualName := cron.Entry(job5).job.(testJob).name; actualName != "job5" {
-		t.Error("wrong job retrieved:", actualName)
-	}
+	assert.Equal(t, "job2", cron.Entry(job2).job.(testJob).name)
+	assert.Equal(t, "job5", cron.Entry(job5).job.(testJob).name)
 
 	cron.Start()
 	defer cron.Stop()
 
 	select {
 	case <-time.After(OneSecond):
-		t.FailNow()
+		require.FailNow(t, "expected job to run")
 	case <-wait(wg):
 	}
 
@@ -554,19 +544,11 @@ func TestJob(t *testing.T) {
 		actuals = append(actuals, entry.job.(testJob).name)
 	}
 
-	for i, expected := range expecteds {
-		if actuals[i] != expected {
-			t.Fatalf("Jobs not in the right order.  (expected) %s != %s (actual)", expecteds, actuals)
-		}
-	}
+	assert.Equal(t, expecteds, actuals, "Jobs not in the right order")
 
 	// Test getting Entries.
-	if actualName := cron.Entry(job2).job.(testJob).name; actualName != "job2" {
-		t.Error("wrong job retrieved:", actualName)
-	}
-	if actualName := cron.Entry(job5).job.(testJob).name; actualName != "job5" {
-		t.Error("wrong job retrieved:", actualName)
-	}
+	assert.Equal(t, "job2", cron.Entry(job2).job.(testJob).name)
+	assert.Equal(t, "job5", cron.Entry(job5).job.(testJob).name)
 }
 
 // Issue #206
@@ -615,7 +597,7 @@ func TestScheduleAfterRemoval(t *testing.T) {
 
 	select {
 	case <-time.After(2 * OneSecond):
-		t.Error("expected job fires 2 times")
+		assert.Fail(t, "expected job fires 2 times")
 	case <-wait(&wg2):
 	}
 }
@@ -635,15 +617,13 @@ func TestJobWithZeroTimeDoesNotRun(t *testing.T) {
 		return nil
 	})
 	cron.Schedule(new(ZeroSchedule), JobFunc(func(context.Context) error {
-		t.Error("expected zero task will not run")
+		assert.Fail(t, "expected zero task will not run")
 		return nil
 	}))
 	cron.Start()
 	defer cron.Stop()
 	<-time.After(OneSecond)
-	if atomic.LoadInt64(&calls) != 1 {
-		t.Errorf("called %d times, expected 1\n", calls)
-	}
+	assert.Equal(t, int64(1), atomic.LoadInt64(&calls))
 }
 
 func TestStopAndWait(t *testing.T) {
@@ -654,7 +634,7 @@ func TestStopAndWait(t *testing.T) {
 		select {
 		case <-ctx.Done():
 		case <-time.After(time.Millisecond):
-			t.Error("context was not done immediately")
+			assert.Fail(t, "context was not done immediately")
 		}
 	})
 
@@ -667,7 +647,7 @@ func TestStopAndWait(t *testing.T) {
 		select {
 		case <-ctx.Done():
 		case <-time.After(time.Millisecond):
-			t.Error("context was not done immediately")
+			assert.Fail(t, "context was not done immediately")
 		}
 	})
 
@@ -683,7 +663,7 @@ func TestStopAndWait(t *testing.T) {
 		select {
 		case <-ctx.Done():
 		case <-time.After(time.Millisecond):
-			t.Error("context was not done immediately")
+			assert.Fail(t, "context was not done immediately")
 		}
 	})
 
@@ -703,7 +683,7 @@ func TestStopAndWait(t *testing.T) {
 		// Verify that it is not done for at least 750ms
 		select {
 		case <-ctx.Done():
-			t.Error("context was done too quickly immediately")
+			assert.Fail(t, "context was done too quickly immediately")
 		case <-time.After(750 * time.Millisecond):
 			// expected, because the job sleeping for 1 second is still running
 		}
@@ -713,7 +693,7 @@ func TestStopAndWait(t *testing.T) {
 		case <-ctx.Done():
 			// expected
 		case <-time.After(1500 * time.Millisecond):
-			t.Error("context not done after job should have completed")
+			assert.Fail(t, "context not done after job should have completed")
 		}
 	})
 
@@ -733,9 +713,9 @@ func TestStopAndWait(t *testing.T) {
 		// Verify that it is not done for at least 1500ms
 		select {
 		case <-ctx.Done():
-			t.Error("context was done too quickly immediately")
+			assert.Fail(t, "context was done too quickly immediately")
 		case <-ctx2.Done():
-			t.Error("context2 was done too quickly immediately")
+			assert.Fail(t, "context2 was done too quickly immediately")
 		case <-time.After(1500 * time.Millisecond):
 			// expected, because the job sleeping for 2 seconds is still running
 		}
@@ -745,7 +725,7 @@ func TestStopAndWait(t *testing.T) {
 		case <-ctx.Done():
 			// expected
 		case <-time.After(time.Second):
-			t.Error("context not done after job should have completed")
+			assert.Fail(t, "context not done after job should have completed")
 		}
 
 		// Verify that ctx2 is also done.
@@ -753,7 +733,7 @@ func TestStopAndWait(t *testing.T) {
 		case <-ctx2.Done():
 			// expected
 		case <-time.After(time.Millisecond):
-			t.Error("context2 not done even though context1 is")
+			assert.Fail(t, "context2 not done even though context1 is")
 		}
 
 		// Verify that a new context retrieved from stop is immediately done.
@@ -762,7 +742,7 @@ func TestStopAndWait(t *testing.T) {
 		case <-ctx3.Done():
 			// expected
 		case <-time.After(time.Millisecond):
-			t.Error("context not done even when cron Stop is completed")
+			assert.Fail(t, "context not done even when cron Stop is completed")
 		}
 	})
 }

--- a/cron_test.go
+++ b/cron_test.go
@@ -119,14 +119,14 @@ func TestAddWhileRunningWithDelay(t *testing.T) {
 	cron.Start()
 	defer cron.Stop()
 	time.Sleep(5 * time.Second)
-	var calls int64
+	var calls atomic.Int64
 	cron.AddFunc("* * * * * *", func(context.Context) error { //nolint:errcheck
-		atomic.AddInt64(&calls, 1)
+		calls.Add(1)
 		return nil
 	})
 
 	<-time.After(OneSecond)
-	assert.Equal(t, int64(1), atomic.LoadInt64(&calls))
+	assert.Equal(t, int64(1), calls.Load())
 }
 
 // Add a job, remove a job, start cron, expect nothing runs.
@@ -611,9 +611,9 @@ func (*ZeroSchedule) Next(time.Time) time.Time {
 // Tests that job without time does not run
 func TestJobWithZeroTimeDoesNotRun(t *testing.T) {
 	cron := newWithSeconds()
-	var calls int64
+	var calls atomic.Int64
 	cron.AddFunc("* * * * * *", func(context.Context) error { //nolint:errcheck
-		atomic.AddInt64(&calls, 1)
+		calls.Add(1)
 		return nil
 	})
 	cron.Schedule(new(ZeroSchedule), JobFunc(func(context.Context) error {
@@ -623,7 +623,7 @@ func TestJobWithZeroTimeDoesNotRun(t *testing.T) {
 	cron.Start()
 	defer cron.Stop()
 	<-time.After(OneSecond)
-	assert.Equal(t, int64(1), atomic.LoadInt64(&calls))
+	assert.Equal(t, int64(1), calls.Load())
 }
 
 func TestStopAndWait(t *testing.T) {

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -2,7 +2,6 @@ package cron
 
 import (
 	"context"
-	"reflect"
 	"sync"
 	"testing"
 
@@ -37,9 +36,7 @@ func TestChain(t *testing.T) {
 		append4 = appendingJob(&nums, 4)
 	)
 	Chain(append1, append2, append3)(append4).Run(t.Context()) //nolint:errcheck
-	if !reflect.DeepEqual(nums, []int{1, 2, 3, 4}) {
-		t.Error("unexpected order of calls:", nums)
-	}
+	assert.Equal(t, []int{1, 2, 3, 4}, nums)
 }
 
 func TestMiddleware_NoopMiddleware(t *testing.T) {

--- a/option_test.go
+++ b/option_test.go
@@ -3,7 +3,6 @@ package cron
 import (
 	"context"
 	"log"
-	"strings"
 	"testing"
 	"time"
 
@@ -19,34 +18,26 @@ func TestWithContext(t *testing.T) {
 
 func TestWithLocation(t *testing.T) {
 	c := New(WithLocation(time.UTC))
-	if c.location != time.UTC {
-		t.Errorf("expected UTC, got %v", c.location)
-	}
+	assert.Equal(t, time.UTC, c.location)
 }
 
 func TestWithParser(t *testing.T) {
 	parser := NewParser(Dow)
 	c := New(WithParser(parser))
-	if c.parser != parser {
-		t.Error("expected provided parser")
-	}
+	assert.Equal(t, parser, c.parser)
 }
 
 func TestWithVerboseLogger(t *testing.T) {
 	var buf syncWriter
 	logger := log.New(&buf, "", log.LstdFlags)
 	c := New(WithLogger(VerbosePrintfLogger(logger)))
-	if c.logger.(printfLogger).logger != logger {
-		t.Error("expected provided logger")
-	}
+	assert.Same(t, logger, c.logger.(printfLogger).logger)
 
 	c.AddFunc("@every 1s", func(context.Context) error { return nil }) //nolint:errcheck
 	c.Start()
 	time.Sleep(OneSecond)
 	c.Stop()
 	out := buf.String()
-	if !strings.Contains(out, "schedule,") ||
-		!strings.Contains(out, "run,") {
-		t.Error("expected to see some actions, got:", out)
-	}
+	assert.Contains(t, out, "schedule,")
+	assert.Contains(t, out, "run,")
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,10 +1,10 @@
 package cron
 
 import (
-	"reflect"
-	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var secondParser = NewParser(Second | Minute | Hour | Dom | Month | DowOptional | Descriptor)
@@ -45,15 +45,12 @@ func TestRange(t *testing.T) {
 
 	for _, c := range ranges {
 		actual, err := getRange(c.expr, bounds{c.min, c.max, nil})
-		if len(c.err) != 0 && (err == nil || !strings.Contains(err.Error(), c.err)) {
-			t.Errorf("%s => expected %v, got %v", c.expr, c.err, err)
+		if c.err != "" {
+			assert.ErrorContains(t, err, c.err, c.expr)
+		} else {
+			assert.NoError(t, err, c.expr)
 		}
-		if len(c.err) == 0 && err != nil {
-			t.Errorf("%s => unexpected error %v", c.expr, err)
-		}
-		if actual != c.expected {
-			t.Errorf("%s => expected %d, got %d", c.expr, c.expected, actual)
-		}
+		assert.Equal(t, c.expected, actual, c.expr)
 	}
 }
 
@@ -71,9 +68,7 @@ func TestField(t *testing.T) {
 
 	for _, c := range fields {
 		actual, _ := getField(c.expr, bounds{c.min, c.max, nil})
-		if actual != c.expected {
-			t.Errorf("%s => expected %d, got %d", c.expr, c.expected, actual)
-		}
+		assert.Equal(t, c.expected, actual, c.expr)
 	}
 }
 
@@ -91,10 +86,7 @@ func TestAll(t *testing.T) {
 
 	for _, c := range allBits {
 		actual := all(c.r) // all() adds the starBit, so compensate for that..
-		if c.expected|starBit != actual {
-			t.Errorf("%d-%d/%d => expected %b, got %b",
-				c.r.min, c.r.max, 1, c.expected|starBit, actual)
-		}
+		assert.Equal(t, c.expected|starBit, actual, "%d-%d/%d", c.r.min, c.r.max, 1)
 	}
 }
 
@@ -111,10 +103,7 @@ func TestBits(t *testing.T) {
 
 	for _, c := range bits {
 		actual := getBits(c.min, c.max, c.step)
-		if c.expected != actual {
-			t.Errorf("%d-%d/%d => expected %b, got %b",
-				c.min, c.max, c.step, c.expected, actual)
-		}
+		assert.Equal(t, c.expected, actual, "%d-%d/%d", c.min, c.max, c.step)
 	}
 }
 
@@ -137,12 +126,8 @@ func TestParseScheduleErrors(t *testing.T) {
 	}
 	for _, c := range tests {
 		actual, err := secondParser.Parse(c.expr)
-		if err == nil || !strings.Contains(err.Error(), c.err) {
-			t.Errorf("%s => expected %v, got %v", c.expr, c.err, err)
-		}
-		if actual != nil {
-			t.Errorf("expected nil schedule on error, got %v", actual)
-		}
+		assert.ErrorContains(t, err, c.err, c.expr)
+		assert.Nil(t, actual)
 	}
 }
 
@@ -182,12 +167,8 @@ func TestParseSchedule(t *testing.T) {
 
 	for _, c := range entries {
 		actual, err := c.parser.Parse(c.expr)
-		if err != nil {
-			t.Errorf("%s => unexpected error %v", c.expr, err)
-		}
-		if !reflect.DeepEqual(actual, c.expected) {
-			t.Errorf("%s => expected %b, got %b", c.expr, c.expected, actual)
-		}
+		assert.NoError(t, err, c.expr)
+		assert.Equal(t, c.expected, actual, c.expr)
 	}
 }
 
@@ -204,12 +185,8 @@ func TestOptionalSecondSchedule(t *testing.T) {
 
 	for _, c := range entries {
 		actual, err := parser.Parse(c.expr)
-		if err != nil {
-			t.Errorf("%s => unexpected error %v", c.expr, err)
-		}
-		if !reflect.DeepEqual(actual, c.expected) {
-			t.Errorf("%s => expected %b, got %b", c.expr, c.expected, actual)
-		}
+		assert.NoError(t, err, c.expr)
+		assert.Equal(t, c.expected, actual, c.expr)
 	}
 }
 
@@ -267,12 +244,8 @@ func TestNormalizeFields(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual, err := normalizeFields(test.input, test.options)
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-			if !reflect.DeepEqual(actual, test.expected) {
-				t.Errorf("expected %v, got %v", test.expected, actual)
-			}
+			assert.NoError(t, err)
+			assert.Equal(t, test.expected, actual)
 		})
 	}
 }
@@ -312,12 +285,7 @@ func TestNormalizeFields_Errors(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual, err := normalizeFields(test.input, test.options)
-			if err == nil {
-				t.Errorf("expected an error, got none. results: %v", actual)
-			}
-			if !strings.Contains(err.Error(), test.err) {
-				t.Errorf("expected error %q, got %q", test.err, err.Error())
-			}
+			assert.ErrorContains(t, err, test.err, "results: %v", actual)
 		})
 	}
 }
@@ -348,24 +316,19 @@ func TestStandardSpecSchedule(t *testing.T) {
 
 	for _, c := range entries {
 		actual, err := ParseStandard(c.expr)
-		if len(c.err) != 0 && (err == nil || !strings.Contains(err.Error(), c.err)) {
-			t.Errorf("%s => expected %v, got %v", c.expr, c.err, err)
+		if c.err != "" {
+			assert.ErrorContains(t, err, c.err, c.expr)
+		} else {
+			assert.NoError(t, err, c.expr)
 		}
-		if len(c.err) == 0 && err != nil {
-			t.Errorf("%s => unexpected error %v", c.expr, err)
-		}
-		if !reflect.DeepEqual(actual, c.expected) {
-			t.Errorf("%s => expected %b, got %b", c.expr, c.expected, actual)
-		}
+		assert.Equal(t, c.expected, actual, c.expr)
 	}
 }
 
 func TestNoDescriptorParser(t *testing.T) {
 	parser := NewParser(Minute | Hour)
 	_, err := parser.Parse("@every 1m")
-	if err == nil {
-		t.Error("expected an error, got none")
-	}
+	assert.Error(t, err, "expected an error, got none")
 }
 
 func every5min(loc *time.Location) *SpecSchedule {

--- a/spec_test.go
+++ b/spec_test.go
@@ -65,8 +65,13 @@ func TestActivation(t *testing.T) {
 		}
 		actual := sched.Next(getTime(test.time).Add(-1 * time.Second))
 		expected := getTime(test.time)
-		assert.Equal(t, test.expected, expected.Equal(actual),
-			"Fail evaluating %s on %s: (expected) %s != %s (actual)", test.spec, test.time, expected, actual)
+		if test.expected {
+			assert.True(t, expected.Equal(actual),
+				"Fail evaluating %s on %s: (expected) %s != %s (actual)", test.spec, test.time, expected, actual)
+		} else {
+			assert.False(t, expected.Equal(actual),
+				"Fail evaluating %s on %s: (expected) %s == %s (actual)", test.spec, test.time, expected, actual)
+		}
 	}
 }
 

--- a/spec_test.go
+++ b/spec_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestActivation(t *testing.T) {
@@ -58,16 +60,13 @@ func TestActivation(t *testing.T) {
 
 	for _, test := range tests {
 		sched, err := ParseStandard(test.spec)
-		if err != nil {
-			t.Error(err)
+		if !assert.NoError(t, err) {
 			continue
 		}
 		actual := sched.Next(getTime(test.time).Add(-1 * time.Second))
 		expected := getTime(test.time)
-		if test.expected && !expected.Equal(actual) || !test.expected && expected.Equal(actual) {
-			t.Errorf("Fail evaluating %s on %s: (expected) %s != %s (actual)",
-				test.spec, test.time, expected, actual)
-		}
+		assert.Equal(t, test.expected, expected.Equal(actual),
+			"Fail evaluating %s on %s: (expected) %s != %s (actual)", test.spec, test.time, expected, actual)
 	}
 }
 
@@ -187,15 +186,12 @@ func TestNext(t *testing.T) {
 
 	for _, c := range runs {
 		sched, err := secondParser.Parse(c.spec)
-		if err != nil {
-			t.Error(err)
+		if !assert.NoError(t, err) {
 			continue
 		}
 		actual := sched.Next(getTime(c.time))
 		expected := getTime(c.expected)
-		if !actual.Equal(expected) {
-			t.Errorf("%s, \"%s\": (expected) %v != %v (actual)", c.time, c.spec, expected, actual)
-		}
+		assert.True(t, actual.Equal(expected), "%s, %q: (expected) %v != %v (actual)", c.time, c.spec, expected, actual)
 	}
 }
 
@@ -208,9 +204,7 @@ func TestErrors(t *testing.T) {
 	}
 	for _, spec := range invalidSpecs {
 		_, err := ParseStandard(spec)
-		if err == nil {
-			t.Error("expected an error parsing: ", spec)
-		}
+		assert.Error(t, err, "expected an error parsing: %s", spec)
 	}
 }
 
@@ -260,15 +254,12 @@ func TestNextWithTz(t *testing.T) {
 	}
 	for _, c := range runs {
 		sched, err := ParseStandard(c.spec)
-		if err != nil {
-			t.Error(err)
+		if !assert.NoError(t, err) {
 			continue
 		}
 		actual := sched.Next(getTimeTZ(c.time))
 		expected := getTimeTZ(c.expected)
-		if !actual.Equal(expected) {
-			t.Errorf("%s, \"%s\": (expected) %v != %v (actual)", c.time, c.spec, expected, actual)
-		}
+		assert.True(t, actual.Equal(expected), "%s, %q: (expected) %v != %v (actual)", c.time, c.spec, expected, actual)
 	}
 }
 
@@ -294,7 +285,5 @@ func getTimeTZ(value string) time.Time {
 func TestSlash0NoHang(t *testing.T) {
 	schedule := "TZ=America/New_York 15/0 * * * *"
 	_, err := ParseStandard(schedule)
-	if err == nil {
-		t.Error("expected an error on 0 increment")
-	}
+	assert.Error(t, err, "expected an error on 0 increment")
 }


### PR DESCRIPTION
## Summary
Migrate the remaining hand-written test assertions in the root module to `github.com/stretchr/testify` helpers.

## Changes
- Replace direct `t.Error`, `t.Fatal`, and `t.Fail` calls with `assert` / `require` helpers
- Replace manual equality and error checks in cron, parser, spec, option, and middleware tests
- Remove now-unused `reflect` and `strings` imports from migrated tests

## Motivation
- Keep test assertions consistent with the rest of the repository, which already uses testify in several modules

## Testing
- `go test ./...`
- `make test` ran through root, delayoverlapping, and distributednooverlapping before the sandbox blocked Redis localhost access
- `make test/./middleware/nooverlapping test/./middleware/otel test/./middleware/recovery test/./tests`
- `make test/./middleware/distributednooverlapping/redismutex`