### PR TITLE
docs: remove Go Report Card badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Package Version](https://badgen.net/github/release/flc1125/go-cron/stable)](https://github.com/flc1125/go-cron/releases)
 [![GoDoc](https://pkg.go.dev/badge/github.com/flc1125/go-cron/v4)](https://pkg.go.dev/github.com/flc1125/go-cron/v4)
 [![codecov](https://codecov.io/gh/flc1125/go-cron/graph/badge.svg?token=mXNvrv22JH)](https://codecov.io/gh/flc1125/go-cron)
-[![Go Report Card](https://goreportcard.com/badge/github.com/flc1125/go-cron)](https://goreportcard.com/report/github.com/flc1125/go-cron)
 [![lint](https://github.com/flc1125/go-cron/actions/workflows/lint.yml/badge.svg)](https://github.com/flc1125/go-cron/actions/workflows/lint.yml)
 [![tests](https://github.com/flc1125/go-cron/actions/workflows/test.yml/badge.svg)](https://github.com/flc1125/go-cron/actions/workflows/test.yml)
 [![MIT license](https://img.shields.io/badge/license-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
## Summary
Remove the Go Report Card badge from the README.

## Changes
- Drop the Go Report Card badge link from the project badge list in `README.md`

## Motivation
- Clean up the README badge row by removing the Go Report Card badge

## Testing
- Not applicable (documentation-only change)