### PR TITLE
Release v4.11.0

### DIFF
--- a/middleware/delayoverlapping/go.mod
+++ b/middleware/delayoverlapping/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/flc1125/go-cron/v4 => ../../
 
 require (
-	github.com/flc1125/go-cron/v4 v4.10.0
+	github.com/flc1125/go-cron/v4 v4.11.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/middleware/distributednooverlapping/go.mod
+++ b/middleware/distributednooverlapping/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/flc1125/go-cron/v4 => ../../
 
 require (
-	github.com/flc1125/go-cron/v4 v4.10.0
+	github.com/flc1125/go-cron/v4 v4.11.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/middleware/distributednooverlapping/redismutex/go.mod
+++ b/middleware/distributednooverlapping/redismutex/go.mod
@@ -8,8 +8,8 @@ replace (
 )
 
 require (
-	github.com/flc1125/go-cron/middleware/distributednooverlapping/v4 v4.10.0
-	github.com/flc1125/go-cron/v4 v4.10.0
+	github.com/flc1125/go-cron/middleware/distributednooverlapping/v4 v4.11.0
+	github.com/flc1125/go-cron/v4 v4.11.0
 	github.com/redis/go-redis/v9 v9.21.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/middleware/nooverlapping/go.mod
+++ b/middleware/nooverlapping/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/flc1125/go-cron/v4 => ../../
 
 require (
-	github.com/flc1125/go-cron/v4 v4.10.0
+	github.com/flc1125/go-cron/v4 v4.11.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/middleware/otel/go.mod
+++ b/middleware/otel/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/flc1125/go-cron/v4 => ../../
 
 require (
-	github.com/flc1125/go-cron/v4 v4.10.0
+	github.com/flc1125/go-cron/v4 v4.11.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/metric v1.44.0

--- a/middleware/recovery/go.mod
+++ b/middleware/recovery/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/flc1125/go-cron/v4 => ../../
 
 require (
-	github.com/flc1125/go-cron/v4 v4.10.0
+	github.com/flc1125/go-cron/v4 v4.11.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -12,12 +12,12 @@ replace (
 )
 
 require (
-	github.com/flc1125/go-cron/middleware/distributednooverlapping/redismutex/v4 v4.10.0
-	github.com/flc1125/go-cron/middleware/distributednooverlapping/v4 v4.10.0
-	github.com/flc1125/go-cron/middleware/nooverlapping/v4 v4.10.0
-	github.com/flc1125/go-cron/middleware/otel/v4 v4.10.0
-	github.com/flc1125/go-cron/middleware/recovery/v4 v4.10.0
-	github.com/flc1125/go-cron/v4 v4.10.0
+	github.com/flc1125/go-cron/middleware/distributednooverlapping/redismutex/v4 v4.11.0
+	github.com/flc1125/go-cron/middleware/distributednooverlapping/v4 v4.11.0
+	github.com/flc1125/go-cron/middleware/nooverlapping/v4 v4.11.0
+	github.com/flc1125/go-cron/middleware/otel/v4 v4.11.0
+	github.com/flc1125/go-cron/middleware/recovery/v4 v4.11.0
+	github.com/flc1125/go-cron/v4 v4.11.0
 	github.com/redis/go-redis/v9 v9.21.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel/sdk v1.44.0

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package cron
 
 func Version() string {
-	return "4.10.0"
+	return "4.11.0"
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 module-sets:
   stable:
-    version: v4.10.0
+    version: v4.11.0
     modules:
       # Core modules
       - github.com/flc1125/go-cron/v4


### PR DESCRIPTION
## Summary

Prepare the **stable** module set for **v4.11.0** on the `4.x` release line.

This PR only performs release-preparation metadata and module alignment. The product history being released is everything already on `4.x` since **v4.10.0** (not the files touched only in this PR).

**Comparison ranges**

| Purpose | Range |
| --- | --- |
| Changes being released | `v4.10.0` (`4222d97`) → PR base `4.x` (`480ea10`) |
| Release PR diff | `480ea10` → `fbc9e23` (`release/v4.11.0`) |

- Released history: https://github.com/flc1125/go-cron/compare/v4.10.0...480ea106615dc0cbea4e0750b818a3afe6b87978
- Release PR diff: https://github.com/flc1125/go-cron/compare/480ea106615dc0cbea4e0750b818a3afe6b87978...fbc9e2364c19f262aeaa11f299fe90b831f7f1bf

## Release Changes

Align all stable release surfaces from **v4.10.0** to **v4.11.0**:

- Bump `versions.yaml` stable module-set version to `v4.11.0` (module membership unchanged)
- Update exported `Version()` in `version.go` to `"4.11.0"`
- Point middleware and integration-test modules at the new core/middleware versions:
  - `middleware/*/go.mod` require `github.com/flc1125/go-cron/v4 v4.11.0`
  - `middleware/distributednooverlapping/redismutex` also requires `distributednooverlapping/v4 v4.11.0`
  - `tests/go.mod` requires core + middleware modules at `v4.11.0`

No public API or runtime behavior is introduced by this preparation diff itself.

## Highlights

Since **v4.10.0**, this release is primarily maintenance:

- **No product feature PRs** and **no breaking API changes** in the released range
- Runtime dependency bumps that affect published middleware modules:
  - OpenTelemetry Go monorepo → **v1.44.0** ([#960](https://github.com/flc1125/go-cron/pull/960)) for `middleware/otel`
  - `github.com/redis/go-redis/v9` → **v9.21.0** ([#962](https://github.com/flc1125/go-cron/pull/962), [#984](https://github.com/flc1125/go-cron/pull/984), [#996](https://github.com/flc1125/go-cron/pull/996)) for `middleware/distributednooverlapping/redismutex`
- Documentation: remove the Go Report Card badge from the README ([#1045](https://github.com/flc1125/go-cron/pull/1045))
- Large volume of tooling, linter, and GitHub Actions dependency updates (exact inventory below)

## Pull Requests Since v4.10.0

Exact inventory for `v4.10.0..480ea10`: **106** merged PRs, **106** commits, no direct commits without a PR. Target release PR **#1046** is excluded.

### Documentation and Repository Structure

- [#1045](https://github.com/flc1125/go-cron/pull/1045): remove Go Report Card badge from README

### Dependencies, CI, and Maintenance

**Runtime / library dependencies that touch published modules**

- [#960](https://github.com/flc1125/go-cron/pull/960): OpenTelemetry Go monorepo → v1.44.0
- [#962](https://github.com/flc1125/go-cron/pull/962): `redis/go-redis/v9` → v9.20.0
- [#984](https://github.com/flc1125/go-cron/pull/984): `redis/go-redis/v9` → v9.20.1
- [#996](https://github.com/flc1125/go-cron/pull/996): `redis/go-redis/v9` → v9.21.0
- Repeated `golang.org/x` updates across the range (for example [#941](https://github.com/flc1125/go-cron/pull/941), [#958](https://github.com/flc1125/go-cron/pull/958), [#964](https://github.com/flc1125/go-cron/pull/964), [#966](https://github.com/flc1125/go-cron/pull/966), [#977](https://github.com/flc1125/go-cron/pull/977), [#982](https://github.com/flc1125/go-cron/pull/982), [#983](https://github.com/flc1125/go-cron/pull/983), [#985](https://github.com/flc1125/go-cron/pull/985), [#1014](https://github.com/flc1125/go-cron/pull/1014), [#1015](https://github.com/flc1125/go-cron/pull/1015), [#1016](https://github.com/flc1125/go-cron/pull/1016), [#1025](https://github.com/flc1125/go-cron/pull/1025), [#1039](https://github.com/flc1125/go-cron/pull/1039), plus related `x/sys` / `x/tools` bumps)

**CI / GitHub Actions**

- [#980](https://github.com/flc1125/go-cron/pull/980): `codecov/codecov-action` → v7
- [#994](https://github.com/flc1125/go-cron/pull/994): `actions/checkout` → v7
- [#1000](https://github.com/flc1125/go-cron/pull/1000) / [#1001](https://github.com/flc1125/go-cron/pull/1001): `actions/cache` → v6
- [#1022](https://github.com/flc1125/go-cron/pull/1022): `actions/setup-go` → v7

**Security / tooling highlights**

- [#949](https://github.com/flc1125/go-cron/pull/949): `go-git` v5.19.1 **[security]** (tooling path; subsequent updates through [#1040](https://github.com/flc1125/go-cron/pull/1040))
- [#934](https://github.com/flc1125/go-cron/pull/934): `golangci-lint/v2` → v2.12.2

**Complete dependency PR set (105 PRs)**

#934, #935, #936, #937, #938, #939, #940, #941, #942, #943, #944, #945, #949, #950, #951, #952, #953, #954, #955, #956, #957, #958, #959, #960, #962, #963, #964, #965, #966, #967, #968, #969, #970, #971, #972, #973, #974, #975, #976, #977, #978, #979, #980, #981, #982, #983, #984, #985, #986, #987, #988, #989, #990, #991, #992, #993, #994, #996, #997, #998, #999, #1000, #1001, #1002, #1003, #1004, #1005, #1006, #1007, #1008, #1009, #1010, #1011, #1012, #1013, #1014, #1015, #1016, #1017, #1018, #1019, #1020, #1022, #1023, #1024, #1025, #1026, #1027, #1028, #1029, #1030, #1031, #1032, #1033, #1034, #1035, #1036, #1037, #1038, #1039, #1040, #1041, #1042, #1043, #1044

Titles for every number above are dependency bumps (`chore(deps)` / `fix(deps)`), primarily Renovate/Dependabot updates to linters, build-tools transitive modules, and CI actions.

## Migration Summary

No migration actions are required for this release.

- Public APIs and middleware contracts are unchanged from v4.10.0
- Consumers who pin OpenTelemetry or `go-redis` transitively via middleware modules will pick up the dependency floors listed above when they upgrade to v4.11.0

## Validation

Observed on PR #1046 at draft time:

- WIP: **SUCCESS**
- Go Lint (`lint`): **IN_PROGRESS**
- Go Test (`go test` on 1.25.x and 1.26.x, ubuntu-latest): **IN_PROGRESS**

Release-preparation consistency checked locally against PR head:

- `versions.yaml` stable version is `v4.11.0`
- `version.go` returns `"4.11.0"`
- Middleware and `tests` module requirements reference `v4.11.0`
- Stable module membership is unchanged from v4.10.0

## Notes

- This is a maintenance release: **0** feature PRs and **0** product bugfix PRs in `v4.10.0..480ea10`
- Inventory count is **106** PRs (**1** docs + **105** dependency/CI); do not add #1046 to that historical set
- Module set still excludes `internal/tools` and `tests/v4` from published tags (unchanged)
