### PR TITLE
ci: make multi-module validation deterministic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,22 @@ jobs:
       - run: go version
 
       - name: Run tests
+        run: make test
+
+      - name: Verify validation failures propagate
+        if: matrix.go-version == '1.26.x'
+        run: |
+          if make GO=false test; then
+            echo "make test unexpectedly succeeded"
+            exit 1
+          fi
+          if make GO=false build; then
+            echo "make build unexpectedly succeeded"
+            exit 1
+          fi
+
+      - name: Generate coverage
+        if: matrix.go-version == '1.26.x' && matrix.platform == 'ubuntu-latest'
         run: make test-coverage
 
       - name: Upload coverage to Codecov

--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,11 @@ build-tests/%: DIR=$*
 build-tests/%:
 	@echo "$(GO) build tests $(DIR)/..." \
 		&& cd $(DIR) \
-		&& $(GO) list ./... \
-		| grep -v third_party \
-		| xargs $(GO) test -vet=off -run xxxxxMatchNothingxxxxx >/dev/null
+		&& packages="$$( $(GO) list ./...)" \
+		&& packages="$$(printf '%s\n' "$$packages" | grep -v third_party || true)" \
+		&& if [ -n "$$packages" ]; then \
+			$(GO) test -vet=off -run xxxxxMatchNothingxxxxx $$packages >/dev/null; \
+		fi
 
 # Tests
 
@@ -70,24 +72,23 @@ test/%: DIR=$*
 test/%:
 	@echo "$(GO) test -timeout $(TIMEOUT)s $(ARGS) $(DIR)/..." \
 		&& cd $(DIR) \
-		&& $(GO) list ./... \
-		| xargs $(GO) test -timeout $(TIMEOUT)s $(ARGS)
+		&& $(GO) test -timeout $(TIMEOUT)s $(ARGS) ./...
 
 
 COVERAGE_MODE    = atomic
 COVERAGE_PROFILE = coverage.out
 .PHONY: test-coverage
 test-coverage: $(GOCOVMERGE)
-	@set -e; \
-	printf "" > coverage.txt; \
+	@set -eu; \
+	profiles=""; \
 	for dir in $(ALL_COVERAGE_MOD_DIRS); do \
-	  echo "$(GO) test -v -race -coverpkg=github.com/flc1125/go-cron/... -covermode=$(COVERAGE_MODE) -coverprofile="$(COVERAGE_PROFILE)" $${dir}/..."; \
+	  echo "cd $${dir} && $(GO) test -timeout $(TIMEOUT)s -coverpkg=./... -covermode=$(COVERAGE_MODE) -coverprofile=$(COVERAGE_PROFILE) ./..."; \
 	  (cd "$${dir}" && \
-	    $(GO) list ./... \
-	    | xargs $(GO) test -coverpkg=./... -covermode=$(COVERAGE_MODE) -coverprofile="$(COVERAGE_PROFILE)" && \
-	  $(GO) tool cover -html=coverage.out -o coverage.html); \
+	    $(GO) test -timeout $(TIMEOUT)s -coverpkg=./... -covermode=$(COVERAGE_MODE) -coverprofile=$(COVERAGE_PROFILE) ./... && \
+	    $(GO) tool cover -html=$(COVERAGE_PROFILE) -o coverage.html); \
+	  profiles="$$profiles $${dir}/$(COVERAGE_PROFILE)"; \
 	done; \
-	$(GOCOVMERGE) $$(find . -name coverage.out) > coverage.txt
+	$(GOCOVMERGE) $$profiles > coverage.txt
 
 .PHONY: golangci-lint golangci-lint-fix
 golangci-lint-fix: ARGS=--fix

--- a/middleware/recovery/recovery_test.go
+++ b/middleware/recovery/recovery_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"log"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -12,9 +13,35 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func newBufferLogger() (*bytes.Buffer, cron.Logger) {
+type signalLogger struct {
+	cron.Logger
+	once   sync.Once
+	logged chan struct{}
+}
+
+func newBufferLogger() (*bytes.Buffer, *signalLogger) {
 	buf := new(bytes.Buffer)
-	return buf, cron.VerbosePrintfLogger(log.New(buf, "", log.LstdFlags))
+	return buf, &signalLogger{
+		Logger: cron.VerbosePrintfLogger(log.New(buf, "", log.LstdFlags)),
+		logged: make(chan struct{}),
+	}
+}
+
+func (l *signalLogger) Error(err error, msg string, keysAndValues ...any) {
+	l.Logger.Error(err, msg, keysAndValues...)
+	l.once.Do(func() {
+		close(l.logged)
+	})
+}
+
+func (l *signalLogger) wait(t *testing.T) {
+	t.Helper()
+
+	select {
+	case <-l.logged:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for recovery log")
+	}
 }
 
 type panicJob struct{}
@@ -56,7 +83,8 @@ func TestRecovery_FuncPanic(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	time.Sleep(time.Second)
+	logger.wait(t)
+	<-c.Stop().Done()
 	assert.True(t, strings.Contains(buf.String(), "YOLO"))
 }
 
@@ -76,7 +104,8 @@ func TestRecovery_JobPanic(t *testing.T) {
 	_, err := c.AddJob("* * * * * ?", panicJob{})
 	assert.NoError(t, err)
 
-	time.Sleep(time.Second)
+	logger.wait(t)
+	<-c.Stop().Done()
 	assert.True(t, strings.Contains(buf.String(), "YOLO"))
 }
 


### PR DESCRIPTION
## Summary
Make multi-module validation deterministic so test, build, and coverage failures are reported reliably without changing runtime behavior.

## Changes
- Run module tests directly with `go test ./...` and preserve `go list` failures during test-build validation
- Generate coverage without race mode and merge only profiles produced by the current run
- Run ordinary tests across the Go matrix, generate coverage on the latest Go version, and verify injected validation failures propagate
- Replace fixed sleeps in recovery scheduler tests with an explicit logger completion signal before reading captured output

## Motivation
- Pipeline-based validation could mask upstream command failures, while stale coverage profiles could be included in reports
- Recovery tests could read their log buffer while a scheduled job was still writing to it

## Testing
- `make lint`
- `make build`
- `make verify-mods`
- `go test -race -count=5 ./...` in `middleware/recovery`
- Verified `make GO=false test` and `make GO=false build` return failures
- Ran all non-Redis module tests successfully
- Completed the coverage workflow for the recovery module
- Full local test and coverage runs reached the Redis-backed module but could not complete because Redis was unavailable; CI provisions the required Redis service
