### PR TITLE
fix(cron): snapshot entry state for job execution

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -245,9 +245,11 @@ func (c *Cron) run() {
 					if e.next.After(now) || e.next.IsZero() {
 						break
 					}
-					c.startJob(e.WrappedJob())
 					e.prev = e.next
 					e.next = e.schedule.Next(now)
+					executionEntry := *e
+					ctx := withExecutionEntryContext(c.ctx, e, &executionEntry)
+					c.startJob(ctx, e.WrappedJob())
 					c.logger.Info("run", "now", now, "entry", e.ID(), "next", e.next)
 				}
 
@@ -279,10 +281,10 @@ func (c *Cron) run() {
 	}
 }
 
-// startJob runs the given job in a new goroutine.
-func (c *Cron) startJob(j Job) {
+// startJob runs the given job with the given context in a new goroutine.
+func (c *Cron) startJob(ctx context.Context, j Job) {
 	c.jobWaiter.Go(func() {
-		j.Run(c.ctx) //nolint:errcheck
+		j.Run(ctx) //nolint:errcheck
 	})
 }
 

--- a/entry.go
+++ b/entry.go
@@ -59,7 +59,11 @@ func newEntry(id EntryID, schedule Schedule, job Job, opts ...EntryOption) *Entr
 	middlewares := append([]Middleware{
 		func(job Job) Job {
 			return JobFunc(func(ctx context.Context) error {
-				return job.Run(WithEntryContext(ctx, entry))
+				runEntry := entry
+				if snapshot, ok := executionEntryFromContext(ctx, entry); ok {
+					runEntry = snapshot
+				}
+				return job.Run(WithEntryContext(ctx, runEntry))
 			})
 		},
 	}, entry.middlewares...)
@@ -101,12 +105,37 @@ func (e *Entry) Job() Job {
 
 type entryContextKey struct{}
 
-// WithEntryContext returns a new context with the given EntryID.
+type executionEntryContextKey struct{}
+
+type executionEntryContextValue struct {
+	registered *Entry
+	snapshot   *Entry
+}
+
+func withExecutionEntryContext(ctx context.Context, registered, snapshot *Entry) context.Context {
+	return context.WithValue(ctx, executionEntryContextKey{}, executionEntryContextValue{
+		registered: registered,
+		snapshot:   snapshot,
+	})
+}
+
+func executionEntryFromContext(ctx context.Context, registered *Entry) (*Entry, bool) {
+	value, ok := ctx.Value(executionEntryContextKey{}).(executionEntryContextValue)
+	if !ok || value.registered != registered {
+		return nil, false
+	}
+	return value.snapshot, true
+}
+
+// WithEntryContext returns a new context with the given Entry.
 func WithEntryContext(ctx context.Context, entry *Entry) context.Context {
 	return context.WithValue(ctx, entryContextKey{}, entry)
 }
 
-// EntryFromContext returns the EntryID from the context.
+// EntryFromContext returns the Entry associated with the current job execution.
+// Jobs started by Cron receive a stable snapshot for that execution. Direct
+// Entry.WrappedJob calls without a scheduler execution context receive the
+// registered Entry.
 func EntryFromContext(ctx context.Context) (*Entry, bool) {
 	entry, ok := ctx.Value(entryContextKey{}).(*Entry)
 	return entry, ok

--- a/entry_test.go
+++ b/entry_test.go
@@ -2,11 +2,14 @@ package cron
 
 import (
 	"context"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEntry_Attributes(t *testing.T) {
@@ -95,4 +98,87 @@ func TestEntry_ContextUseCron(t *testing.T) {
 	assert.NotNil(t, e1.Load())
 	assert.NotNil(t, e2.Load())
 	assert.NotEqual(t, e1.Load().(*Entry).id, e2.Load().(*Entry).id)
+}
+
+func TestEntry_ExecutionContextIsScopedToRegisteredEntry(t *testing.T) {
+	var firstSeen, secondSeen *Entry
+	first := newEntry(1, nil, JobFunc(func(ctx context.Context) error {
+		firstSeen, _ = EntryFromContext(ctx)
+		return nil
+	}))
+	second := newEntry(2, nil, JobFunc(func(ctx context.Context) error {
+		secondSeen, _ = EntryFromContext(ctx)
+		return nil
+	}))
+	executionSnapshot := *first
+	executionSnapshot.prev = time.Unix(1, 0)
+	executionSnapshot.next = time.Unix(2, 0)
+	executionCtx := withExecutionEntryContext(t.Context(), first, &executionSnapshot)
+
+	assert.NoError(t, first.WrappedJob().Run(executionCtx))
+	assert.Same(t, &executionSnapshot, firstSeen)
+
+	assert.NoError(t, second.WrappedJob().Run(executionCtx))
+	assert.Same(t, second, secondSeen)
+
+	assert.NoError(t, first.WrappedJob().Run(t.Context()))
+	assert.Same(t, first, firstSeen)
+}
+
+type entrySnapshotSchedule time.Duration
+
+func (s entrySnapshotSchedule) Next(now time.Time) time.Time {
+	return now.Add(time.Duration(s))
+}
+
+func TestCron_EntryExecutionSnapshot(t *testing.T) {
+	entries := make(chan *Entry, 16)
+	release := make(chan struct{})
+	job := JobFunc(func(ctx context.Context) error {
+		entry, _ := EntryFromContext(ctx)
+		entries <- entry
+		for {
+			select {
+			case <-release:
+				return nil
+			default:
+				_ = entry.Prev()
+				_ = entry.Next()
+				runtime.Gosched()
+			}
+		}
+	})
+
+	c := New()
+	id := c.Schedule(entrySnapshotSchedule(20*time.Millisecond), job)
+	c.Start()
+	defer c.Stop()
+
+	readEntry := func() *Entry {
+		t.Helper()
+		select {
+		case entry := <-entries:
+			require.NotNil(t, entry)
+			return entry
+		case <-time.After(2 * time.Second):
+			require.FailNow(t, "timed out waiting for scheduled entry")
+			return nil
+		}
+	}
+
+	first := readEntry()
+	firstPrev, firstNext := first.Prev(), first.Next()
+	second := readEntry()
+	close(release)
+	<-c.Stop().Done()
+
+	assert.Equal(t, id, first.ID())
+	assert.Equal(t, id, second.ID())
+	assert.NotSame(t, first, second)
+	assert.False(t, firstPrev.IsZero())
+	assert.True(t, firstNext.After(firstPrev))
+	assert.Equal(t, firstNext, second.Prev())
+	assert.True(t, second.Next().After(second.Prev()))
+	assert.Equal(t, firstPrev, first.Prev())
+	assert.Equal(t, firstNext, first.Next())
 }

--- a/middleware/distributednooverlapping/distributednooverlapping_test.go
+++ b/middleware/distributednooverlapping/distributednooverlapping_test.go
@@ -78,6 +78,12 @@ func (l contextCheckingLock) Unlock(ctx context.Context) error {
 	return nil
 }
 
+type scheduledTestSchedule time.Duration
+
+func (s scheduledTestSchedule) Next(now time.Time) time.Time {
+	return now.Add(time.Duration(s))
+}
+
 type spyMutex struct {
 	lock     Lock
 	acquired bool
@@ -223,6 +229,44 @@ func TestMiddleware_RunBranches(t *testing.T) {
 				assert.Equal(t, tt.wantUnlocks, tt.mutex.lock.(*spyLock).unlockCalls)
 			}
 		})
+	}
+}
+
+func TestMiddleware_ScheduledEntrySnapshotRetainsOriginalJob(t *testing.T) {
+	mutex := &spyMutex{lock: &spyLock{}, acquired: true}
+	entries := make(chan *cron.Entry, 1)
+	job := testJob{
+		name: "scheduled",
+		ttl:  time.Second,
+		Job: cron.JobFunc(func(ctx context.Context) error {
+			entry, _ := cron.EntryFromContext(ctx)
+			entries <- entry
+			return nil
+		}),
+	}
+	c := cron.New(cron.WithMiddleware(New(mutex, WithLogger(cron.DiscardLogger))))
+	id := c.Schedule(scheduledTestSchedule(500*time.Millisecond), job)
+	c.Start()
+	defer c.Stop()
+
+	var entry *cron.Entry
+	select {
+	case entry = <-entries:
+		if !assert.NotNil(t, entry) {
+			return
+		}
+	case <-time.After(2 * time.Second):
+		assert.FailNow(t, "timed out waiting for scheduled entry")
+	}
+	<-c.Stop().Done()
+
+	entryJob, ok := entry.Job().(testJob)
+	assert.True(t, ok)
+	assert.Equal(t, id, entry.ID())
+	assert.Equal(t, job.name, entryJob.name)
+	assert.Equal(t, 1, mutex.lockCalls)
+	if assert.NotNil(t, mutex.job) {
+		assert.Equal(t, job.name, mutex.job.GetMutexKey())
 	}
 }
 

--- a/middleware/otel/otel_test.go
+++ b/middleware/otel/otel_test.go
@@ -42,6 +42,27 @@ func (m *mockJob) Run(ctx context.Context) error {
 	return m.err
 }
 
+type fixedDelaySchedule time.Duration
+
+func (s fixedDelaySchedule) Next(now time.Time) time.Time {
+	return now.Add(time.Duration(s))
+}
+
+type scheduledEntryJob struct {
+	name    string
+	entries chan<- *cron.Entry
+}
+
+func (j *scheduledEntryJob) Name() string {
+	return j.name
+}
+
+func (j *scheduledEntryJob) Run(ctx context.Context) error {
+	entry, _ := cron.EntryFromContext(ctx)
+	j.entries <- entry
+	return nil
+}
+
 func TestTracing(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -91,6 +112,37 @@ func TestTracing(t *testing.T) {
 			tt.extraTesting(t, span)
 		})
 	}
+}
+
+func TestTracing_ScheduledEntrySnapshot(t *testing.T) {
+	defer imsb.Reset()
+
+	entries := make(chan *cron.Entry, 1)
+	c := cron.New(cron.WithMiddleware(middleware))
+	id := c.Schedule(fixedDelaySchedule(500*time.Millisecond), &scheduledEntryJob{
+		name:    "scheduled-entry",
+		entries: entries,
+	})
+	c.Start()
+	defer c.Stop()
+
+	var entry *cron.Entry
+	select {
+	case entry = <-entries:
+		require.NotNil(t, entry)
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "timed out waiting for scheduled entry")
+	}
+	<-c.Stop().Done()
+
+	require.Len(t, imsb.GetSpans(), 1)
+	span := imsb.GetSpans()[0]
+	assert.Equal(t, id, entry.ID())
+	assert.False(t, entry.Prev().IsZero())
+	assert.True(t, entry.Next().After(entry.Prev()))
+	assert.Contains(t, span.Attributes, attribute.Int("cron.job.id", int(id)))
+	assert.Contains(t, span.Attributes, attrJobPrevTime.String(entry.Prev().String()))
+	assert.Contains(t, span.Attributes, attrJobNextTime.String(entry.Next().String()))
 }
 
 func TestTracing_PassThroughWithoutNamedEntryJob(t *testing.T) {


### PR DESCRIPTION
## Summary
Give each scheduler-started job a stable per-execution `Entry` snapshot so middleware and jobs can read `Prev` and `Next` without racing scheduler updates. Public method signatures remain unchanged.

## Changes
- Advance the registered Entry before job launch, then pass a shallow execution snapshot through an internal Context value scoped to that registration
- Define snapshot timing as `Prev` = the current scheduled activation and `Next` = the next activation calculated from the scheduler wake time
- Preserve direct `Entry.WrappedJob` behavior by falling back to the registered Entry when no scheduler execution Context is present
- Keep the original `Job` and `Schedule` references in each snapshot so middleware metadata contracts continue to work
- Add race and behavior coverage for consecutive snapshots, nested wrapped jobs, OTel span timing, and distributed mutex job detection

## Motivation
- Scheduled jobs currently receive the mutable registered Entry while the scheduler updates its timing fields, causing data races and nondeterministic OTel attributes
- Each execution needs stable timing values without changing the public Entry Context API

## Testing
- `go test -race -run 'TestEntry|TestCron_EntryExecutionSnapshot' ./...`
- `go test -race -count=20 -run 'TestEntry_ExecutionContextIsScopedToRegisteredEntry|TestCron_EntryExecutionSnapshot' ./...`
- `go test -race ./...` in the root, `middleware/otel`, and `middleware/distributednooverlapping` modules
- Repeated the new OTel and distributed scheduler tests five times under the race detector
- `make lint`
- `make build`
- `make verify-mods`
- `make gorelease` reported no incompatible API changes; existing missing-sum diagnostics remain in several submodules whose manifests are unchanged by this PR

## Notes
- A repeated local run reproduced the existing wall-clock sensitivity in `TestJobWithZeroTimeDoesNotRun`; an independent full root race run passed. This PR does not change that test.
