### PR TITLE
fix(cron): isolate job waiters across restarts

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -15,17 +15,21 @@ type Cron struct {
 	entries       []*Entry
 	middlewares   []Middleware
 	middlewaresMu sync.Mutex
-	stop          chan struct{}
 	add           chan *Entry
 	remove        chan EntryID
 	snapshot      chan chan []Entry
-	running       bool
-	logger        Logger
 	runningMu     sync.Mutex
+	running       bool
+	runState      *runState
+	logger        Logger
 	location      *time.Location
 	parser        ScheduleParser
 	nextID        EntryID
-	jobWaiter     sync.WaitGroup
+}
+
+type runState struct {
+	stop chan struct{}
+	jobs sync.WaitGroup
 }
 
 // ScheduleParser is an interface for schedule spec parsers that return a Schedule
@@ -81,7 +85,6 @@ func New(opts ...Option) *Cron {
 		ctx:       context.Background(),
 		entries:   nil,
 		add:       make(chan *Entry),
-		stop:      make(chan struct{}),
 		snapshot:  make(chan chan []Entry),
 		remove:    make(chan EntryID),
 		running:   false,
@@ -187,31 +190,39 @@ func (c *Cron) Remove(id EntryID) {
 }
 
 // Start the cron scheduler in its own goroutine, or no-op if already started.
+// Jobs started by each successful call are tracked independently from jobs
+// left running by earlier calls.
 func (c *Cron) Start() {
 	c.runningMu.Lock()
 	defer c.runningMu.Unlock()
 	if c.running {
 		return
 	}
+	state := newRunState()
+	c.runState = state
 	c.running = true
-	go c.run()
+	go c.run(state)
 }
 
-// Run the cron scheduler, or no-op if already running.
+// Run the cron scheduler, or no-op if already running. Jobs started by each
+// successful call are tracked independently from jobs left running by earlier
+// calls.
 func (c *Cron) Run() {
 	c.runningMu.Lock()
 	if c.running {
 		c.runningMu.Unlock()
 		return
 	}
+	state := newRunState()
+	c.runState = state
 	c.running = true
 	c.runningMu.Unlock()
-	c.run()
+	c.run(state)
 }
 
 // run the scheduler.. this is private just due to the need to synchronize
 // access to the 'running' state variable.
-func (c *Cron) run() {
+func (c *Cron) run(state *runState) {
 	c.logger.Info("start")
 
 	// Figure out the next activation times for each entry.
@@ -249,7 +260,7 @@ func (c *Cron) run() {
 					e.next = e.schedule.Next(now)
 					executionEntry := *e
 					ctx := withExecutionEntryContext(c.ctx, e, &executionEntry)
-					c.startJob(ctx, e.WrappedJob())
+					state.startJob(ctx, e.WrappedJob())
 					c.logger.Info("run", "now", now, "entry", e.ID(), "next", e.next)
 				}
 
@@ -264,7 +275,7 @@ func (c *Cron) run() {
 				replyChan <- c.entrySnapshot()
 				continue
 
-			case <-c.stop:
+			case <-state.stop:
 				timer.Stop()
 				c.logger.Info("stop")
 				return
@@ -281,9 +292,13 @@ func (c *Cron) run() {
 	}
 }
 
+func newRunState() *runState {
+	return &runState{stop: make(chan struct{})}
+}
+
 // startJob runs the given job with the given context in a new goroutine.
-func (c *Cron) startJob(ctx context.Context, j Job) {
-	c.jobWaiter.Go(func() {
+func (s *runState) startJob(ctx context.Context, j Job) {
+	s.jobs.Go(func() {
 		j.Run(ctx) //nolint:errcheck
 	})
 }
@@ -293,18 +308,25 @@ func (c *Cron) now() time.Time {
 	return time.Now().In(c.location)
 }
 
-// Stop stops the cron scheduler if it is running; otherwise it does nothing.
-// A context is returned so the caller can wait for running jobs to complete.
+// Stop stops the cron scheduler if it is running. A context is returned so the
+// caller can wait for jobs started by that run to complete. If the scheduler is
+// not running, the context waits for jobs from the most recent run. It does not
+// wait for jobs started by later calls to Start or Run.
 func (c *Cron) Stop() context.Context {
 	c.runningMu.Lock()
 	defer c.runningMu.Unlock()
 	if c.running {
-		c.stop <- struct{}{}
+		c.runState.stop <- struct{}{}
 		c.running = false
 	}
+	state := c.runState
 	ctx, cancel := context.WithCancel(context.Background())
+	if state == nil {
+		cancel()
+		return ctx
+	}
 	go func() {
-		c.jobWaiter.Wait()
+		state.jobs.Wait()
 		cancel()
 	}()
 	return ctx

--- a/cron_test.go
+++ b/cron_test.go
@@ -536,11 +536,14 @@ func TestNonLocalTimezone(t *testing.T) {
 	}
 }
 
-// Test that calling stop before start silently returns without
-// blocking the stop channel.
-func TestStopWithoutStart(*testing.T) {
+// Test that calling stop before start returns an already-completed context.
+func TestStopWithoutStart(t *testing.T) {
 	cron := New()
-	cron.Stop()
+	select {
+	case <-cron.Stop().Done():
+	case <-time.After(time.Second):
+		t.Fatal("Stop context did not complete")
+	}
 }
 
 type testJob struct {
@@ -851,6 +854,130 @@ func TestStopAndWait(t *testing.T) {
 			assert.Fail(t, "context not done even when cron Stop is completed")
 		}
 	})
+}
+
+// oncePerRunSchedule fires once each time the scheduler initializes its entries.
+type oncePerRunSchedule struct {
+	calls atomic.Int64
+}
+
+func (s *oncePerRunSchedule) Next(now time.Time) time.Time {
+	if s.calls.Add(1)%2 == 1 {
+		return now
+	}
+	return time.Time{}
+}
+
+func TestCron_RestartWaitsForJobsByRun(t *testing.T) {
+	startMethods := []struct {
+		name  string
+		start func(*Cron)
+	}{
+		{name: "Start", start: func(cron *Cron) { cron.Start() }},
+		{name: "Run", start: func(cron *Cron) { go cron.Run() }},
+	}
+
+	for _, method := range startMethods {
+		t.Run(method.name, func(t *testing.T) {
+			testCronRestartWaitsForJobsByRun(t, method.start)
+		})
+	}
+}
+
+func testCronRestartWaitsForJobsByRun(t *testing.T, start func(*Cron)) {
+	tests := []struct {
+		name          string
+		firstFinished int64
+	}{
+		{name: "old run finishes first", firstFinished: 1},
+		{name: "new run finishes first", firstFinished: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			started := make(chan int64, 2)
+			releases := []chan struct{}{
+				make(chan struct{}, 1),
+				make(chan struct{}, 1),
+			}
+			var runs atomic.Int64
+
+			cron := New()
+			cron.Schedule(&oncePerRunSchedule{}, JobFunc(func(context.Context) error {
+				run := runs.Add(1)
+				started <- run
+				if run <= int64(len(releases)) {
+					<-releases[run-1]
+				}
+				return nil
+			}))
+			t.Cleanup(func() {
+				for _, release := range releases {
+					select {
+					case release <- struct{}{}:
+					default:
+					}
+				}
+				cron.Stop()
+			})
+
+			waitForRun := func(want int64) {
+				t.Helper()
+				select {
+				case got := <-started:
+					require.Equal(t, want, got)
+				case <-time.After(time.Second):
+					t.Fatalf("job for run %d did not start", want)
+				}
+			}
+			waitForDone := func(ctx context.Context, name string) {
+				t.Helper()
+				select {
+				case <-ctx.Done():
+				case <-time.After(time.Second):
+					t.Fatalf("%s did not complete", name)
+				}
+			}
+			assertNotDone := func(ctx context.Context, name string) {
+				t.Helper()
+				select {
+				case <-ctx.Done():
+					t.Fatalf("%s completed while its job was still running", name)
+				default:
+				}
+			}
+
+			start(cron)
+			waitForRun(1)
+			oldRun := cron.Stop()
+			repeatedOldRun := cron.Stop()
+			assertNotDone(oldRun, "old run Stop context")
+			assertNotDone(repeatedOldRun, "repeated old run Stop context")
+
+			start(cron)
+			waitForRun(2)
+			newRun := cron.Stop()
+			assertNotDone(newRun, "new run Stop context")
+
+			releases[tt.firstFinished-1] <- struct{}{}
+			if tt.firstFinished == 1 {
+				waitForDone(oldRun, "old run Stop context")
+				waitForDone(repeatedOldRun, "repeated old run Stop context")
+				assertNotDone(newRun, "new run Stop context")
+			} else {
+				waitForDone(newRun, "new run Stop context")
+				assertNotDone(oldRun, "old run Stop context")
+				assertNotDone(repeatedOldRun, "repeated old run Stop context")
+			}
+
+			otherRun := int64(3) - tt.firstFinished
+			releases[otherRun-1] <- struct{}{}
+			waitForDone(oldRun, "old run Stop context")
+			waitForDone(repeatedOldRun, "repeated old run Stop context")
+			waitForDone(newRun, "new run Stop context")
+			require.Equal(t, int64(2), runs.Load())
+		})
+	}
 }
 
 func TestCron_IsRunning(t *testing.T) {


### PR DESCRIPTION
## Summary
Isolate scheduler lifecycle state by run so each Stop context waits only for jobs started by the run it stopped.

## Changes
- Add a private runState with a per-run stop channel and job WaitGroup for both Start and Run
- Preserve repeated Stop behavior while preventing later runs from extending earlier Stop contexts
- Document the per-run lifecycle contract and add deterministic restart tests for both job completion orders

## Motivation
- Reusing one job waiter across restarts could overlap WaitGroup.Wait with later WaitGroup.Go calls and made Stop contexts span multiple runs
- Immediate restart should remain safe without cancelling jobs that are still running from the previous run

## Testing
- go test -race -run 'TestStop|TestCron_Restart|TestCron_IsRunning' ./...
- go test -race -count=100 -run '^TestCron_RestartWaitsForJobsByRun$' ./...
- go test ./...
- make lint
- make build
- Compared gorelease output with the 4.x baseline; no additional compatibility diagnostics