### PR TITLE
ci: enforce race tests across all modules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       - run: go version
 
       - name: Run tests
-        run: make test
+        run: make test-race
 
       - name: Verify validation failures propagate
         if: matrix.go-version == '1.26.x'


### PR DESCRIPTION
## Summary
Enforce the race detector across every stable module in both supported Go test jobs.

## Changes
- Run `make test-race` for the Go 1.25 and Go 1.26 matrix entries
- Keep coverage as a separate non-race step on Go 1.26
- Preserve the existing Redis service, module matrix, and validation-failure checks

## Motivation
- The known scheduler, entry snapshot, middleware registration, and recovery test races are now fixed
- Running the race detector on every pull request prevents those concurrency issues from regressing

## Testing
- `make test-race` across all 8 stable modules: passed in 82.69s; the slowest module completed in 39.87s under the 60s per-module timeout
- `make test-coverage`: passed in 64.73s
- `make lint`
- `make build`
- `make verify-mods`
- GitHub Actions passed on Go 1.25 and Go 1.26

## CI Timing
- Go 1.25 test step: 51s baseline, 100s with race; total job increased from 1m32s to 2m13s
- Go 1.26 test step: 57s baseline, 92s with race; total job increased from 2m36s to 3m16s
- The slowest individual module remains below its 60s timeout