### PR TITLE
docs: align cron lifecycle and error semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,11 @@ func main() {
 	c := cron.New(
 		cron.WithSeconds(), // if you want to use seconds, you can use this option
 		cron.WithMiddleware(
-			recovery.New(),      // recover panic
-			nooverlapping.New(), // prevent job overlapping
+			recovery.New(), // recover panic
 		),
 		cron.WithContext(context.Background()), // use custom context
 		// ... other options
 	)
-
-	// use middleware
-	c.Use(recovery.New(), nooverlapping.New()) // use middleware
 
 	// add job
 	entryID, _ := c.AddJob("* * * * * *", cron.JobFunc(func(ctx context.Context) error {
@@ -65,13 +61,13 @@ func main() {
 	_, _ = c.AddFunc("* * * * * *", func(ctx context.Context) error {
 		// do something
 		return nil
-	}, recovery.New(), nooverlapping.New()) // use middleware for this job
+	}, nooverlapping.New()) // use middleware for this job
 
 	// start cron
 	c.Start()
 
-	// stop cron
-	c.Stop()
+	// stop future scheduling and wait for jobs started by this run
+	<-c.Stop().Done()
 }
 ```
 
@@ -82,6 +78,53 @@ func main() {
 - [nooverlapping](./middleware/nooverlapping): Prevents concurrent execution of the same job.
 - [distributednooverlapping](./middleware/distributednooverlapping): Prevents concurrent execution across multiple instances using distributed locking.
 - [otel](./middleware/otel): Provides OpenTelemetry integration for job execution tracing and metrics.
+
+### Registration and order
+
+`WithMiddleware` configures the initial middleware chain. `Use` appends middleware
+only for jobs registered after `Use` returns; it does not modify existing entries.
+`Use` is safe to call concurrently with job registration.
+
+Middleware runs in registration order. For example, `Chain(m1, m2)` produces
+`m1(m2(job))`. Cron-level middleware configured through `WithMiddleware` or `Use`
+runs outside middleware passed to an individual `AddFunc`, `AddJob`, or `Schedule`
+call.
+
+## Lifecycle
+
+`Stop` prevents the current scheduler run from starting more jobs. It does not
+cancel jobs that have already started. The returned context is done after jobs
+started by that run have completed:
+
+```go
+c.Start()
+// ...
+<-c.Stop().Done()
+```
+
+A stopped `Cron` may be started again without waiting for the previous Stop
+context. Jobs left running by the previous run may overlap jobs started by the
+new run. Each Stop context waits only for its own run and is not extended by a
+later `Start` or `Run` call.
+
+## Job errors and panics
+
+The scheduler ignores the error returned by `Job.Run`. `WithLogger` configures
+scheduler messages; it does not log or otherwise handle Job errors. Handle errors
+inside the Job or with middleware. Middleware such as `otel` may observe an error
+before returning it to the scheduler.
+
+Panic recovery is not enabled by default. Add the
+[`recovery`](./middleware/recovery) middleware explicitly when jobs or downstream
+middleware must be recovered.
+
+## Entry context
+
+Jobs started by the scheduler can call `EntryFromContext` to inspect a stable
+Entry snapshot for that execution. `Prev` is the scheduled activation time for
+the current execution, and `Next` is the next scheduled activation time already
+calculated by the scheduler. The scheduler does not mutate that snapshot after
+the Job starts.
 
 ## License
 

--- a/cron.go
+++ b/cron.go
@@ -7,9 +7,9 @@ import (
 	"time"
 )
 
-// Cron keeps track of any number of entries, invoking the associated func as
-// specified by the schedule. It may be started, stopped, and the entries may
-// be inspected while running.
+// Cron keeps track of any number of entries, invoking the associated [Job] as
+// specified by its [Schedule]. It may be started, stopped, and inspected while
+// running.
 type Cron struct {
 	ctx           context.Context
 	entries       []*Entry
@@ -32,7 +32,7 @@ type runState struct {
 	jobs sync.WaitGroup
 }
 
-// ScheduleParser is an interface for schedule spec parsers that return a Schedule
+// ScheduleParser parses schedule specifications into [Schedule] values.
 type ScheduleParser interface {
 	Parse(spec string) (Schedule, error)
 }
@@ -63,23 +63,20 @@ func (s byTime) Less(i, j int) bool {
 	return s[i].next.Before(s[j].next)
 }
 
-// New returns a new Cron job runner, modified by the given options.
+// New returns a new [Cron] job runner, modified by the given [Option] values.
 //
-// Available Settings
+// Available settings:
 //
-//	Time Zone
-//	  Description: The time zone in which schedules are interpreted
-//	  Default:     time.Local
+//   - Time zone: controls how schedules are interpreted. The default is
+//     [time.Local].
+//   - Parser: converts specifications into [Schedule] values using a
+//     [ScheduleParser]. The default accepts the standard cron format described
+//     at https://en.wikipedia.org/wiki/Cron.
+//   - Middleware: wraps submitted [Job] values with [Middleware]. The default
+//     is no middleware.
 //
-//	Parser
-//	  Description: Parser converts cron spec strings into cron.Schedules.
-//	  Default:     Accepts this spec: https://en.wikipedia.org/wiki/Cron
-//
-//	Chain
-//	  Description: Wrap submitted jobs to customize behavior.
-//	  Default:     A chain that recovers panics and logs them to stderr.
-//
-// See "cron.With*" to modify the default behavior.
+// See [WithContext], [WithLocation], [WithSeconds], [WithParser],
+// [WithMiddleware], and [WithLogger] to modify the default behavior.
 func New(opts ...Option) *Cron {
 	c := &Cron{
 		ctx:       context.Background(),
@@ -99,7 +96,8 @@ func New(opts ...Option) *Cron {
 	return c
 }
 
-// Use appends middleware to the chain of jobs registered after Use returns.
+// Use appends middleware to the chain of jobs registered after [Cron.Use]
+// returns.
 // It does not affect previously registered jobs and is safe to call concurrently
 // with job registration.
 func (c *Cron) Use(middleware ...Middleware) {
@@ -109,16 +107,16 @@ func (c *Cron) Use(middleware ...Middleware) {
 	c.middlewares = append(c.middlewares, middleware...)
 }
 
-// AddFunc adds a func to the Cron to be run on the given schedule.
-// The spec is parsed using the time zone of this Cron instance as the default.
-// An opaque id is returned that can be used to later remove it.
+// AddFunc adds a function to the [Cron] to be run on the given schedule.
+// The spec is parsed using the time zone of this [Cron] instance as the default.
+// An opaque [EntryID] is returned that can be used to later remove it.
 func (c *Cron) AddFunc(spec string, cmd func(ctx context.Context) error, middlewares ...Middleware) (EntryID, error) {
 	return c.AddJob(spec, JobFunc(cmd), middlewares...)
 }
 
-// AddJob adds a Job to the Cron to be run on the given schedule.
-// The spec is parsed using the time zone of this Cron instance as the default.
-// An opaque id is returned that can be used to later remove it.
+// AddJob adds a [Job] to the [Cron] to be run on the given schedule.
+// The spec is parsed using the time zone of this [Cron] instance as the default.
+// An opaque [EntryID] is returned that can be used to later remove it.
 func (c *Cron) AddJob(spec string, cmd Job, middlewares ...Middleware) (EntryID, error) {
 	schedule, err := c.parser.Parse(spec)
 	if err != nil {
@@ -127,8 +125,8 @@ func (c *Cron) AddJob(spec string, cmd Job, middlewares ...Middleware) (EntryID,
 	return c.Schedule(schedule, cmd, middlewares...), nil
 }
 
-// Schedule adds a Job to the Cron to be run on the given schedule.
-// The job is wrapped with the configured Chain.
+// Schedule adds a [Job] to the [Cron] to be run on the given [Schedule].
+// The job is wrapped with the configured [Middleware].
 func (c *Cron) Schedule(schedule Schedule, cmd Job, middlewares ...Middleware) EntryID {
 	c.runningMu.Lock()
 	defer c.runningMu.Unlock()
@@ -151,7 +149,7 @@ func (c *Cron) Schedule(schedule Schedule, cmd Job, middlewares ...Middleware) E
 	return entry.id
 }
 
-// Entries returns a snapshot of the cron entries.
+// Entries returns a snapshot of the [Cron] entries.
 func (c *Cron) Entries() []Entry {
 	c.runningMu.Lock()
 	defer c.runningMu.Unlock()
@@ -163,12 +161,13 @@ func (c *Cron) Entries() []Entry {
 	return c.entrySnapshot()
 }
 
-// Location gets the time zone location
+// Location returns the [time.Location] used by the [Cron].
 func (c *Cron) Location() *time.Location {
 	return c.location
 }
 
-// Entry returns a snapshot of the given entry, or nil if it couldn't be found.
+// Entry returns a snapshot of the given [Entry], or a zero [Entry] if it could
+// not be found.
 func (c *Cron) Entry(id EntryID) Entry {
 	for _, entry := range c.Entries() {
 		if id == entry.id {
@@ -178,7 +177,7 @@ func (c *Cron) Entry(id EntryID) Entry {
 	return Entry{}
 }
 
-// Remove an entry from being run in the future.
+// Remove prevents the [Entry] identified by id from running in the future.
 func (c *Cron) Remove(id EntryID) {
 	c.runningMu.Lock()
 	defer c.runningMu.Unlock()
@@ -190,8 +189,8 @@ func (c *Cron) Remove(id EntryID) {
 }
 
 // Start the cron scheduler in its own goroutine, or no-op if already started.
-// Jobs started by each successful call are tracked independently from jobs
-// left running by earlier calls.
+// Calls to [Job.Run] started by each successful call are tracked independently
+// from jobs left running by earlier calls.
 func (c *Cron) Start() {
 	c.runningMu.Lock()
 	defer c.runningMu.Unlock()
@@ -204,9 +203,9 @@ func (c *Cron) Start() {
 	go c.run(state)
 }
 
-// Run the cron scheduler, or no-op if already running. Jobs started by each
-// successful call are tracked independently from jobs left running by earlier
-// calls.
+// Run starts the cron scheduler in the current goroutine, or no-ops if it is
+// already running. Calls to [Job.Run] started by each successful call are
+// tracked independently from jobs left running by earlier calls.
 func (c *Cron) Run() {
 	c.runningMu.Lock()
 	if c.running {
@@ -308,10 +307,11 @@ func (c *Cron) now() time.Time {
 	return time.Now().In(c.location)
 }
 
-// Stop stops the cron scheduler if it is running. A context is returned so the
-// caller can wait for jobs started by that run to complete. If the scheduler is
-// not running, the context waits for jobs from the most recent run. It does not
-// wait for jobs started by later calls to Start or Run.
+// Stop stops the cron scheduler if it is running. A [context.Context] is
+// returned so the caller can wait for jobs started by that run to complete. If
+// the scheduler is not running, the context waits for jobs from the most recent
+// run. It does not wait for jobs started by later calls to [Cron.Start] or
+// [Cron.Run].
 func (c *Cron) Stop() context.Context {
 	c.runningMu.Lock()
 	defer c.runningMu.Unlock()

--- a/doc.go
+++ b/doc.go
@@ -1,15 +1,14 @@
 // Package cron provides a cron job scheduler for Go applications.
 //
 // This package is a fork of robfig/cron with significant improvements including
-// context support, middleware system, better error handling, and enhanced
-// scheduling capabilities.
+// context support, a middleware system, and enhanced scheduling capabilities.
 //
 // # Basic Usage
 //
 // Creating and starting a basic cron scheduler:
 //
 //	c := cron.New()
-//	c.AddFunc("0 30 * * * *", func(ctx context.Context) error {
+//	c.AddFunc("30 * * * *", func(ctx context.Context) error {
 //		fmt.Println("Every hour on the half hour")
 //		return nil
 //	})
@@ -62,16 +61,15 @@
 //
 //	c := cron.New(
 //		cron.WithMiddleware(
-//			recovery.New(),      // Recover from panics
-//			nooverlapping.New(), // Prevent job overlapping
+//			recovery.New(), // Recover from panics
 //		),
 //	)
 //
 //	// Apply middleware to specific jobs
-//	c.AddFunc("* * * * *", myFunc, recovery.New())
+//	c.AddFunc("* * * * *", myFunc, nooverlapping.New())
 //
-//	// Use middleware on running cron
-//	c.Use(recovery.New(), nooverlapping.New())
+//	// Apply middleware to jobs registered after this call
+//	c.Use(nooverlapping.New())
 //
 // Available middleware:
 //   - recovery: Recovers from panics in job execution
@@ -99,6 +97,10 @@
 //   - Value passing between middleware and jobs
 //   - Graceful shutdown coordination
 //
+// [Cron.Stop] does not cancel this context. To cancel running jobs during
+// shutdown, pass a cancellable context with [WithContext] and cancel it
+// explicitly.
+//
 // # Lifecycle Management
 //
 //	c := cron.New()
@@ -115,25 +117,36 @@
 //	// Remove jobs
 //	c.Remove(entryID)
 //
-//	// Stop the scheduler (waits for running jobs)
-//	c.Stop()
+//	// Stop future scheduling and wait for jobs started by this run
+//	<-c.Stop().Done()
+//
+// [Cron.Stop] does not cancel jobs that have already started. The [Cron] may be
+// started again before the context returned by the previous [Cron.Stop] is
+// done; jobs from the two runs may overlap, and each returned context waits
+// only for jobs from its own run.
 //
 //	// Get current entries
 //	entries := c.Entries()
 //
 // # Error Handling
 //
-// Jobs can return errors, which are handled by the configured logger:
+// The scheduler ignores errors returned by [Job.Run]. [WithLogger] configures
+// scheduler messages and does not handle job errors. Handle errors inside the
+// [Job] or with [Middleware]:
 //
 //	c.AddFunc("* * * * *", func(ctx context.Context) error {
 //		if err := doSomething(); err != nil {
+//			recordJobError(err)
 //			return fmt.Errorf("job failed: %w", err)
 //		}
 //		return nil
 //	})
 //
+// Panics are not recovered by default. Configure the recovery middleware
+// explicitly when panic recovery is required.
+//
 // # Thread Safety
 //
-// The cron scheduler is thread-safe and can be safely accessed from multiple
-// goroutines. All public methods are protected by appropriate synchronization.
+// [Cron] is thread-safe and can be safely accessed from multiple goroutines.
+// All public methods are protected by appropriate synchronization.
 package cron

--- a/entry.go
+++ b/entry.go
@@ -5,10 +5,10 @@ import (
 	"time"
 )
 
-// EntryID identifies an entry within a Cron instance
+// EntryID identifies an [Entry] within a [Cron] instance.
 type EntryID int
 
-// Entry consists of a schedule and the func to execute on that schedule.
+// Entry consists of a [Schedule] and the [Job] to execute on that schedule.
 type Entry struct {
 	// id is the cron-assigned id of this entry, which may be used to look up a
 	// snapshot or remove it.
@@ -36,8 +36,10 @@ type Entry struct {
 	middlewares []Middleware
 }
 
+// EntryOption configures an [Entry].
 type EntryOption func(*Entry)
 
+// WithEntryMiddlewares configures the [Middleware] applied to an [Entry].
 func WithEntryMiddlewares(middlewares ...Middleware) EntryOption {
 	return func(e *Entry) {
 		e.middlewares = middlewares
@@ -74,6 +76,7 @@ func newEntry(id EntryID, schedule Schedule, job Job, opts ...EntryOption) *Entr
 	return entry
 }
 
+// ID returns the [EntryID] assigned by [Cron].
 func (e *Entry) ID() EntryID {
 	return e.id
 }
@@ -81,22 +84,27 @@ func (e *Entry) ID() EntryID {
 // Valid returns true if this is not the zero entry.
 func (e *Entry) Valid() bool { return e.id != 0 }
 
+// Schedule returns the [Schedule] associated with the entry.
 func (e *Entry) Schedule() Schedule {
 	return e.schedule
 }
 
+// Next returns the next scheduled activation time.
 func (e *Entry) Next() time.Time {
 	return e.next
 }
 
+// Prev returns the previous scheduled activation time.
 func (e *Entry) Prev() time.Time {
 	return e.prev
 }
 
+// WrappedJob returns the [Job] after its [Middleware] has been applied.
 func (e *Entry) WrappedJob() Job {
 	return e.wrappedJob
 }
 
+// Job returns the originally registered [Job].
 func (e *Entry) Job() Job {
 	return e.job
 }
@@ -127,15 +135,18 @@ func executionEntryFromContext(ctx context.Context, registered *Entry) (*Entry, 
 	return value.snapshot, true
 }
 
-// WithEntryContext returns a new context with the given Entry.
+// WithEntryContext returns a new [context.Context] containing the given [Entry].
 func WithEntryContext(ctx context.Context, entry *Entry) context.Context {
 	return context.WithValue(ctx, entryContextKey{}, entry)
 }
 
-// EntryFromContext returns the Entry associated with the current job execution.
-// Jobs started by Cron receive a stable snapshot for that execution. Direct
-// Entry.WrappedJob calls without a scheduler execution context receive the
-// registered Entry.
+// EntryFromContext returns the [Entry] associated with the current job
+// execution. Jobs started by [Cron] receive a stable snapshot for that
+// execution. Direct [Entry.WrappedJob] calls without a scheduler execution
+// context receive the registered [Entry]. In a scheduler execution snapshot,
+// [Entry.Prev] is the scheduled activation time for that execution and
+// [Entry.Next] is the next scheduled activation time already calculated by the
+// scheduler.
 func EntryFromContext(ctx context.Context) (*Entry, bool) {
 	entry, ok := ctx.Value(entryContextKey{}).(*Entry)
 	return entry, ok

--- a/middleware/otel/README.md
+++ b/middleware/otel/README.md
@@ -1,6 +1,7 @@
 # OTel Middleware
 
-The `otel` is a middleware for that provides observability with OpenTelemetry.
+The `otel` middleware provides OpenTelemetry traces and metrics for cron Job
+executions.
 
 > [!WARNING]  
 > **Unstable Semantic Conventions**
@@ -8,6 +9,25 @@ The `otel` is a middleware for that provides observability with OpenTelemetry.
 > OpenTelemetry has not yet defined semantic conventions that align with cron job scheduling and execution. As a result, all metrics, attributes, and trace semantics provided by this middleware are custom-defined and subject to change.
 >
 > These conventions will remain unstable until OTel releases official semantic conventions for cron-like workloads. When that happens, this middleware will be updated to adopt the official conventions, which **will be a breaking change** that may require updates to your dashboards, queries, and alerting rules.
+
+## Behavior
+
+Scheduler Jobs are instrumented only when the registered Job implements
+`JobWithName`. Calls without an Entry context and Jobs without a name run without
+cron trace or metric data.
+
+When an instrumented Job returns an error, the middleware records it on the span
+and metrics, then returns the error unchanged. The core scheduler does not log or
+otherwise handle that returned error, so applications still need Job-level or
+additional middleware error handling.
+
+The `cron.job.prev.time` and `cron.job.next.time` span attributes come from the
+stable Entry snapshot for that execution. They represent the current scheduled
+activation time and the next scheduled activation time, respectively.
+
+Middleware order is outermost to innermost. To recover panics raised by OTel or
+the Job, register recovery before OTel, for example
+`cron.WithMiddleware(recovery.New(), otel.New())`.
 
 ## Usage
 
@@ -56,9 +76,8 @@ func main() {
 	_, _ = c.AddJob("* * * * * *", &basicJob{})
 
 	c.Start()
-	defer c.Stop()
-
 	time.Sleep(10 * time.Second)
+	<-c.Stop().Done()
 	fmt.Println("spans:", len(imsb.GetSpans()))
 }
 ```

--- a/middleware/recovery/README.md
+++ b/middleware/recovery/README.md
@@ -1,6 +1,16 @@
 # Recovery Middleware
 
-The `recovery` middleware is a middleware for [go-cron](https://github.com/flc1125/go-cron) that recovers from panics.
+The `recovery` middleware recovers panics raised by the Job or middleware it
+wraps and logs the panic and stack trace. Panic recovery is not enabled by
+default; register this middleware explicitly when it is required.
+
+Returned Job errors pass through unchanged. When a panic is recovered, that
+execution returns a nil error after the panic has been logged.
+
+Middleware order is outermost to innermost. Register recovery before any
+middleware whose panics it should catch. For example,
+`cron.WithMiddleware(recovery.New(), other)` produces
+`recovery(other(job))`.
 
 ## Usage
 
@@ -16,19 +26,21 @@ import (
 )
 
 func main() {
-	c := cron.New()
-	c.Use(recovery.New(
-		recovery.WithLogger(cron.DefaultLogger), // if not set, use cron.DefaultLogger
-	))
+	c := cron.New(
+		cron.WithSeconds(),
+		cron.WithMiddleware(
+			recovery.New(
+				recovery.WithLogger(cron.DefaultLogger), // default: cron.DefaultLogger
+			),
+		),
+	)
 
 	_, _ = c.AddFunc("* * * * * *", func(context.Context) error {
 		panic("YOLO")
 	})
 
 	c.Start()
-	defer c.Stop()
-
 	time.Sleep(2 * time.Second)
+	<-c.Stop().Done()
 }
-
 ```

--- a/option.go
+++ b/option.go
@@ -5,46 +5,49 @@ import (
 	"time"
 )
 
-// Option represents a modification to the default behavior of a Cron.
+// Option represents a modification to the default behavior of a [Cron].
 type Option func(*Cron)
 
-// WithContext overrides the context used by the Cron.
+// WithContext overrides the [context.Context] used by the [Cron].
 func WithContext(ctx context.Context) Option {
 	return func(c *Cron) {
 		c.ctx = ctx
 	}
 }
 
-// WithLocation overrides the timezone of the cron instance.
+// WithLocation overrides the [time.Location] used by the [Cron].
 func WithLocation(loc *time.Location) Option {
 	return func(c *Cron) {
 		c.location = loc
 	}
 }
 
-// WithSeconds overrides the parser used for interpreting job schedules to
-// include a seconds field as the first one.
+// WithSeconds overrides the [ScheduleParser] used for interpreting job
+// schedules to include a seconds field as the first one.
 func WithSeconds() Option {
 	return WithParser(NewParser(
 		Second | Minute | Hour | Dom | Month | Dow | Descriptor,
 	))
 }
 
-// WithParser overrides the parser used for interpreting job schedules.
+// WithParser overrides the [ScheduleParser] used for interpreting job
+// schedules.
 func WithParser(p ScheduleParser) Option {
 	return func(c *Cron) {
 		c.parser = p
 	}
 }
 
-// WithMiddleware specifies Middleware to apply to all jobs added to this cron.
+// WithMiddleware specifies [Middleware] to apply to all jobs added to the
+// [Cron].
 func WithMiddleware(middlewares ...Middleware) Option {
 	return func(c *Cron) {
 		c.middlewares = middlewares
 	}
 }
 
-// WithLogger uses the provided logger.
+// WithLogger uses the provided [Logger] for scheduler messages. It does not
+// handle errors returned by [Job.Run].
 func WithLogger(logger Logger) Option {
 	return func(c *Cron) {
 		c.logger = logger


### PR DESCRIPTION
## Summary
Align the public documentation with the scheduler's current lifecycle, middleware, error, and Entry snapshot semantics. This is a documentation-only change with no API or runtime behavior changes.

## Changes
- Clarify that middleware and panic recovery are opt-in, `Use` affects only subsequently registered jobs, and middleware runs outermost to innermost
- Document that Job errors are ignored by the core scheduler and that each Stop context waits only for jobs started by its own scheduler run
- Describe stable Entry execution snapshots and update GoDoc comments, symbol links, and examples to follow current Go documentation conventions

## Motivation
- Existing docs described default recovery, Job error handling, and Stop behavior differently from the implementation, which could lead users to rely on guarantees the scheduler does not provide

## Testing
- `make lint`
- `make build`
- `make test-race`
- `make test-coverage` (passed on rerun; the first run hit the existing Stop timing flake)
- `make verify-mods`
- `make gorelease` (no new compatibility diagnostics)
- `go vet ./...`
- Rendered the updated API docs with `go doc`
- `git diff --check`
