### PR TITLE
Release v4.12.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ _backup
 .todo
 _example
 .tools
+.docs

--- a/middleware/delayoverlapping/go.mod
+++ b/middleware/delayoverlapping/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 replace github.com/flc1125/go-cron/v4 => ../../
 
 require (
-	github.com/flc1125/go-cron/v4 v4.11.0
+	github.com/flc1125/go-cron/v4 v4.12.0
 	github.com/stretchr/testify v1.12.1
 )
 

--- a/middleware/distributednooverlapping/go.mod
+++ b/middleware/distributednooverlapping/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 replace github.com/flc1125/go-cron/v4 => ../../
 
 require (
-	github.com/flc1125/go-cron/v4 v4.11.0
+	github.com/flc1125/go-cron/v4 v4.12.0
 	github.com/stretchr/testify v1.12.1
 )
 

--- a/middleware/distributednooverlapping/redismutex/go.mod
+++ b/middleware/distributednooverlapping/redismutex/go.mod
@@ -8,8 +8,8 @@ replace (
 )
 
 require (
-	github.com/flc1125/go-cron/middleware/distributednooverlapping/v4 v4.11.0
-	github.com/flc1125/go-cron/v4 v4.11.0
+	github.com/flc1125/go-cron/middleware/distributednooverlapping/v4 v4.12.0
+	github.com/flc1125/go-cron/v4 v4.12.0
 	github.com/redis/go-redis/v9 v9.22.0
 	github.com/stretchr/testify v1.12.1
 )

--- a/middleware/nooverlapping/go.mod
+++ b/middleware/nooverlapping/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 replace github.com/flc1125/go-cron/v4 => ../../
 
 require (
-	github.com/flc1125/go-cron/v4 v4.11.0
+	github.com/flc1125/go-cron/v4 v4.12.0
 	github.com/stretchr/testify v1.12.1
 )
 

--- a/middleware/otel/go.mod
+++ b/middleware/otel/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 replace github.com/flc1125/go-cron/v4 => ../../
 
 require (
-	github.com/flc1125/go-cron/v4 v4.11.0
+	github.com/flc1125/go-cron/v4 v4.12.0
 	github.com/stretchr/testify v1.12.1
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/metric v1.45.0

--- a/middleware/recovery/go.mod
+++ b/middleware/recovery/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 replace github.com/flc1125/go-cron/v4 => ../../
 
 require (
-	github.com/flc1125/go-cron/v4 v4.11.0
+	github.com/flc1125/go-cron/v4 v4.12.0
 	github.com/stretchr/testify v1.12.1
 )
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -12,12 +12,12 @@ replace (
 )
 
 require (
-	github.com/flc1125/go-cron/middleware/distributednooverlapping/redismutex/v4 v4.11.0
-	github.com/flc1125/go-cron/middleware/distributednooverlapping/v4 v4.11.0
-	github.com/flc1125/go-cron/middleware/nooverlapping/v4 v4.11.0
-	github.com/flc1125/go-cron/middleware/otel/v4 v4.11.0
-	github.com/flc1125/go-cron/middleware/recovery/v4 v4.11.0
-	github.com/flc1125/go-cron/v4 v4.11.0
+	github.com/flc1125/go-cron/middleware/distributednooverlapping/redismutex/v4 v4.12.0
+	github.com/flc1125/go-cron/middleware/distributednooverlapping/v4 v4.12.0
+	github.com/flc1125/go-cron/middleware/nooverlapping/v4 v4.12.0
+	github.com/flc1125/go-cron/middleware/otel/v4 v4.12.0
+	github.com/flc1125/go-cron/middleware/recovery/v4 v4.12.0
+	github.com/flc1125/go-cron/v4 v4.12.0
 	github.com/redis/go-redis/v9 v9.22.0
 	github.com/stretchr/testify v1.12.1
 	go.opentelemetry.io/otel/sdk v1.45.0

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package cron
 
 func Version() string {
-	return "4.11.0"
+	return "4.12.0"
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 module-sets:
   stable:
-    version: v4.11.0
+    version: v4.12.0
     modules:
       # Core modules
       - github.com/flc1125/go-cron/v4


### PR DESCRIPTION
## Summary

Prepare the **stable** module set for **v4.12.0** on the `4.x` release line.

This PR only performs release-preparation metadata, module alignment, and a small ignore-file update. The product history being released is everything already on `4.x` since **v4.11.0** (not the files touched only in this PR).

**Comparison ranges**

| Purpose | Range |
| --- | --- |
| Changes being released | `v4.11.0` (`282296a`) → PR base `4.x` (`8aef1ad`) |
| Release PR diff | `8aef1ad` → `cad78e7` (`release/v4.12.0`) |

- Released history: https://github.com/flc1125/go-cron/compare/v4.11.0...8aef1ad5fe0c919ef901a5b4788035c0b83c29ae
- Release PR diff: https://github.com/flc1125/go-cron/compare/8aef1ad5fe0c919ef901a5b4788035c0b83c29ae...cad78e74bad26d162590d0497bb25d3a5251a4d7

## Release Changes

Align all stable release surfaces from **v4.11.0** to **v4.12.0**:

- Bump `versions.yaml` stable module-set version to `v4.12.0` (module membership unchanged)
- Update exported `Version()` in `version.go` to `"4.12.0"`
- Point middleware and integration-test modules at the new core/middleware versions:
  - `middleware/*/go.mod` require `github.com/flc1125/go-cron/v4 v4.12.0`
  - `middleware/distributednooverlapping/redismutex` also requires `distributednooverlapping/v4 v4.12.0`
  - `tests/go.mod` requires core + middleware modules at `v4.12.0`
- Add `.docs` to `.gitignore`

No public API is introduced by this preparation diff itself.

## Highlights

Since **v4.11.0**, this release raises the Go floor and ships three scheduler concurrency fixes:

- **Breaking:** minimum Go version is **1.26**; CI also tests **Go 1.27** ([#1091](https://github.com/flc1125/go-cron/pull/1091))
- Scheduler lifecycle and concurrency corrections (public method signatures unchanged):
  - Isolate job waiters so each `Stop` context waits only for jobs started by that run ([#1074](https://github.com/flc1125/go-cron/pull/1074))
  - Give each scheduled execution a stable `Entry` snapshot for `Prev` / `Next` ([#1073](https://github.com/flc1125/go-cron/pull/1073))
  - Synchronize `Use` with job registration so concurrent middleware setup is race-free ([#1072](https://github.com/flc1125/go-cron/pull/1072))
- Documentation: align lifecycle, middleware, error, and Entry-snapshot semantics with the implementation ([#1077](https://github.com/flc1125/go-cron/pull/1077))
- Runtime dependency bumps that affect published middleware modules:
  - OpenTelemetry Go monorepo → **v1.45.0** ([#1049](https://github.com/flc1125/go-cron/pull/1049)) for `middleware/otel`
  - `github.com/redis/go-redis/v9` → **v9.22.0** ([#1048](https://github.com/flc1125/go-cron/pull/1048)) for `middleware/distributednooverlapping/redismutex`
  - `github.com/stretchr/testify` → **v1.12.1** ([#1075](https://github.com/flc1125/go-cron/pull/1075), [#1082](https://github.com/flc1125/go-cron/pull/1082))
- CI: deterministic multi-module validation ([#1071](https://github.com/flc1125/go-cron/pull/1071)) and race tests on every stable module ([#1076](https://github.com/flc1125/go-cron/pull/1076))

## Pull Requests Since v4.11.0

Exact inventory for `v4.11.0..8aef1ad`: **40** merged PRs, **40** commits, no direct commits without a PR. Target release PR **#1093** is excluded.

### Breaking Changes

- [#1091](https://github.com/flc1125/go-cron/pull/1091): require Go **1.26** and add Go **1.27** support
  - Every module `go` directive is `1.26.0`; Go 1.25 is no longer a supported build toolchain
  - Test matrix is Go 1.26 and Go 1.27 (lint, coverage, and validation-failure checks use 1.27)
  - Tooling aligned for 1.27 analysis (`golangci-lint/v2` → v2.13.1, gofumpt formatter setting migrated)
  - Public Go APIs are otherwise unchanged by this PR

### Fixes and Behavioral Changes

- [#1074](https://github.com/flc1125/go-cron/pull/1074): isolate job waiters across restarts so a `Stop` context is not extended by a later `Start`/`Run`
- [#1073](https://github.com/flc1125/go-cron/pull/1073): snapshot `Entry` timing fields per execution so middleware and jobs can read `Prev`/`Next` without racing scheduler updates
- [#1072](https://github.com/flc1125/go-cron/pull/1072): synchronize middleware registration; `Use` remains concurrent-safe and still affects only jobs registered after it returns

### Documentation and Repository Structure

- [#1077](https://github.com/flc1125/go-cron/pull/1077): align public docs with current lifecycle, middleware ordering, ignored Job errors, per-run `Stop` waiters, and Entry execution snapshots

### Dependencies, CI, and Maintenance

**CI / repository validation**

- [#1071](https://github.com/flc1125/go-cron/pull/1071): make multi-module test, build, and coverage validation deterministic
- [#1076](https://github.com/flc1125/go-cron/pull/1076): enforce race tests across all stable modules

**Runtime / library dependencies that touch published modules**

- [#1049](https://github.com/flc1125/go-cron/pull/1049): OpenTelemetry Go monorepo → v1.45.0
- [#1048](https://github.com/flc1125/go-cron/pull/1048): `redis/go-redis/v9` → v9.22.0
- [#1075](https://github.com/flc1125/go-cron/pull/1075) / [#1082](https://github.com/flc1125/go-cron/pull/1082): `stretchr/testify` → v1.12.1
- Repeated `golang.org/x` updates across the range ([#1050](https://github.com/flc1125/go-cron/pull/1050), [#1058](https://github.com/flc1125/go-cron/pull/1058), [#1061](https://github.com/flc1125/go-cron/pull/1061), [#1065](https://github.com/flc1125/go-cron/pull/1065), [#1068](https://github.com/flc1125/go-cron/pull/1068), [#1087](https://github.com/flc1125/go-cron/pull/1087))

**Complete dependency PR set (33 PRs)**

#1047, #1048, #1049, #1050, #1051, #1052, #1053, #1054, #1055, #1056, #1057, #1058, #1059, #1061, #1062, #1063, #1064, #1065, #1066, #1067, #1068, #1069, #1070, #1075, #1078, #1079, #1080, #1081, #1082, #1085, #1087, #1090, #1092

Titles for every number above are dependency bumps (`chore(deps)` / `fix(deps)`), primarily Renovate updates to linters, build-tools transitive modules, `golang.org/x`, OpenTelemetry, `go-redis`, and `testify`.

## Migration Summary

Consumers must build with **Go 1.26 or newer**. Go 1.25 is no longer supported.

No other migration actions are required for public APIs:

- Method signatures and middleware contracts are unchanged from v4.11.0
- `Use` still applies only to jobs registered after it returns
- Job errors remain ignored by the core scheduler
- Each `Stop` context now waits only for jobs started by the run it stopped (a correction of previous waiter reuse across restarts)
- Scheduled jobs and middleware now observe a per-execution `Entry` snapshot rather than the live registered entry while the scheduler mutates timing fields
- Consumers who pin OpenTelemetry or `go-redis` transitively via middleware modules will pick up the dependency floors listed above when they upgrade to v4.12.0

## Validation

Observed on PR #1093:

- WIP: **SUCCESS**
- Go Lint (`lint`): **SUCCESS**
- Go Test (`go test` on 1.26.x and 1.27.x, ubuntu-latest): **SUCCESS**

Release-preparation consistency checked against PR head:

- `versions.yaml` stable version is `v4.12.0`
- `version.go` returns `"4.12.0"`
- Middleware and `tests` module requirements reference `v4.12.0`
- Stable module membership is unchanged from v4.11.0
- Module `go` directives and the repository-wide assertion are `go 1.26.0`

## Notes

- Inventory count is **40** PRs (**1** breaking toolchain + **3** scheduler fixes + **1** docs + **2** CI + **33** dependency); do not add #1093 to that historical set
- Module set still excludes `internal/tools` and `tests/v4` from published tags (unchanged)
- The `.gitignore` `.docs` entry exists only on this release branch and is not part of the v4.11.0..`4.x` product history
