### PR TITLE
Release v4.13.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ _backup
 _example
 .tools
 .docs
+.agents/
+skills-lock.json

--- a/middleware/delayoverlapping/go.mod
+++ b/middleware/delayoverlapping/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 replace github.com/flc1125/go-cron/v4 => ../../
 
 require (
-	github.com/flc1125/go-cron/v4 v4.12.0
+	github.com/flc1125/go-cron/v4 v4.13.0
 	github.com/stretchr/testify v1.12.1
 )
 

--- a/middleware/distributednooverlapping/go.mod
+++ b/middleware/distributednooverlapping/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 replace github.com/flc1125/go-cron/v4 => ../../
 
 require (
-	github.com/flc1125/go-cron/v4 v4.12.0
+	github.com/flc1125/go-cron/v4 v4.13.0
 	github.com/stretchr/testify v1.12.1
 )
 

--- a/middleware/distributednooverlapping/redismutex/go.mod
+++ b/middleware/distributednooverlapping/redismutex/go.mod
@@ -8,8 +8,8 @@ replace (
 )
 
 require (
-	github.com/flc1125/go-cron/middleware/distributednooverlapping/v4 v4.12.0
-	github.com/flc1125/go-cron/v4 v4.12.0
+	github.com/flc1125/go-cron/middleware/distributednooverlapping/v4 v4.13.0
+	github.com/flc1125/go-cron/v4 v4.13.0
 	github.com/redis/go-redis/v9 v9.22.0
 	github.com/stretchr/testify v1.12.1
 )

--- a/middleware/nooverlapping/go.mod
+++ b/middleware/nooverlapping/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 replace github.com/flc1125/go-cron/v4 => ../../
 
 require (
-	github.com/flc1125/go-cron/v4 v4.12.0
+	github.com/flc1125/go-cron/v4 v4.13.0
 	github.com/stretchr/testify v1.12.1
 )
 

--- a/middleware/otel/go.mod
+++ b/middleware/otel/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 replace github.com/flc1125/go-cron/v4 => ../../
 
 require (
-	github.com/flc1125/go-cron/v4 v4.12.0
+	github.com/flc1125/go-cron/v4 v4.13.0
 	github.com/stretchr/testify v1.12.1
 	go.opentelemetry.io/otel v1.46.0
 	go.opentelemetry.io/otel/metric v1.46.0

--- a/middleware/recovery/go.mod
+++ b/middleware/recovery/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 replace github.com/flc1125/go-cron/v4 => ../../
 
 require (
-	github.com/flc1125/go-cron/v4 v4.12.0
+	github.com/flc1125/go-cron/v4 v4.13.0
 	github.com/stretchr/testify v1.12.1
 )
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -12,12 +12,12 @@ replace (
 )
 
 require (
-	github.com/flc1125/go-cron/middleware/distributednooverlapping/redismutex/v4 v4.12.0
-	github.com/flc1125/go-cron/middleware/distributednooverlapping/v4 v4.12.0
-	github.com/flc1125/go-cron/middleware/nooverlapping/v4 v4.12.0
-	github.com/flc1125/go-cron/middleware/otel/v4 v4.12.0
-	github.com/flc1125/go-cron/middleware/recovery/v4 v4.12.0
-	github.com/flc1125/go-cron/v4 v4.12.0
+	github.com/flc1125/go-cron/middleware/distributednooverlapping/redismutex/v4 v4.13.0
+	github.com/flc1125/go-cron/middleware/distributednooverlapping/v4 v4.13.0
+	github.com/flc1125/go-cron/middleware/nooverlapping/v4 v4.13.0
+	github.com/flc1125/go-cron/middleware/otel/v4 v4.13.0
+	github.com/flc1125/go-cron/middleware/recovery/v4 v4.13.0
+	github.com/flc1125/go-cron/v4 v4.13.0
 	github.com/redis/go-redis/v9 v9.22.0
 	github.com/stretchr/testify v1.12.1
 	go.opentelemetry.io/otel/sdk v1.46.0

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package cron
 
 func Version() string {
-	return "4.12.0"
+	return "4.13.0"
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 module-sets:
   stable:
-    version: v4.12.0
+    version: v4.13.0
     modules:
       # Core modules
       - github.com/flc1125/go-cron/v4


### PR DESCRIPTION
## Summary

Prepare the **stable** module set for **v4.13.0** on the `4.x` release line.

| Purpose | Verified range |
| --- | --- |
| Changes being released | `v4.12.0` (`93cd4ef`) → `4.x` (`cc94ec4`) |
| Release-preparation diff | `cc94ec4` → `52b12ff` (`release/v4.13.0`) |

- [Released history](https://github.com/flc1125/go-cron/compare/93cd4ef72a03c9f7ff71c54871440f1bbafa0ae0...cc94ec49b4aa8ce2a05b3e6c309757876edfcc1f)
- [Release-preparation diff](https://github.com/flc1125/go-cron/compare/cc94ec49b4aa8ce2a05b3e6c309757876edfcc1f...52b12ff29395ec9d7cf50894aa89c3b762225e8a)

## Release Changes

- Set the stable version in `versions.yaml` to `v4.13.0` and update `Version()` to return `"4.13.0"`.
- Align core and middleware requirements in all middleware modules and `tests/go.mod` with `v4.13.0`.
- Add `.agents/` and `skills-lock.json` to `.gitignore` so release tooling recognizes these local files as ignored.

The stable release group contains the core module and six middleware modules. `internal/tools` and `tests` remain excluded from published module tags.

## Highlights

The history since `v4.12.0` consists of dependency maintenance:

- OpenTelemetry dependencies in `middleware/otel` and integration tests advance from **v1.45.0 to v1.46.0** (#1099).
- `golang.org/x/sys` advances from **v0.47.0 to v0.48.0** in the Redis mutex, OpenTelemetry, and test modules (#1126).
- Development tooling updates include `golangci-lint/v2` **v2.13.2**, `gofumpt` **v0.12.0**, and refreshed linter dependencies.

The repository diff introduces no scheduler API or behavior changes, and the Go minimum remains **1.26.0**. Consumers of the affected middleware modules will pick up the updated dependency versions.

## Pull Requests Since v4.12.0

Exact inventory for `93cd4ef..cc94ec4`: **35 merged PRs across 35 commits**, all dependency updates. Each PR's merge commit was verified against this range; there are no direct commits without a PR. This release-preparation PR is excluded.

### Published-module dependencies

- #1099 — OpenTelemetry Go monorepo → v1.46.0.
- #1126 — Refresh `golang.org/x`, including `x/sys` → v0.48.0 in published middleware modules and corresponding tooling updates.

### Development tooling dependencies

- #1083 — `golangci-lint/v2` → v2.13.2.
- #1094 — `uudashr/iface` → v1.5.1.
- #1095 — `mvdan.cc/unparam` → digest `2fa3d84`.
- #1096 — Refresh `golang.org/x` tooling dependencies.
- #1098 — `sirupsen/logrus` → v1.10.2.
- #1100 — `securego/gosec/v2` → v2.29.0.
- #1101 — `raeperd/recvcheck` → v0.3.1.
- #1102 — `gofrs/flock` → v0.13.1.
- #1103 — `skeema/knownhosts` → v1.3.3.
- #1106 — `prometheus/procfs` → v0.22.0.
- #1107 — `godoc-lint/godoc-lint` → v0.11.4.
- #1109 — `timonwong/loggercheck` → v0.12.0.
- #1110 — `4meepo/tagalign` → v1.4.4.
- #1111 — `prometheus/client_model` → v0.6.3.
- #1112 — `prometheus/common` → v0.71.0.
- #1113, #1115, #1117, #1120, #1123, #1130 — Refresh `charmbracelet/ultraviolet`, ending at digest `6c9e17d`.
- #1114 — `golangci/rowserrcheck` → digest `241134d`.
- #1116, #1128 — `mattn/go-runewidth` → v0.0.29, then v0.0.30.
- #1118 — `golang.org/x/crypto` → v0.56.0; subsequently advanced to v0.57.0 by #1126.
- #1119 — `go-critic/go-critic` → v0.15.0.
- #1121 — `exhaustruct/v5` → v5.2.0.
- #1122, #1124 — `dlclark/regexp2/v2` → v2.7.2, then v2.8.0.
- #1125 — `mvdan.cc/gofumpt` → v0.12.0.
- #1127 — `fatcontext` → v0.10.1.
- #1129 — `sourcegraph/go-diff` → v0.9.0.
- #1131 — `dave/dst` → v0.28.0.

## Validation

- `make prerelease MODSET=stable` — passed, including module-set verification and module tidying; generated version-alignment changes are included in this PR.
- `git diff --check origin/4.x...HEAD` — passed.
- Verified stable manifest, exported version, and internal module requirements consistently reference v4.13.0.
- Before release preparation, `make gorelease` suggested **v4.13.0** for `redismutex` and `otel`, and **v4.12.1** for the other stable modules. The unified release adopts v4.13.0. That run also reported missing `go.sum` entries in middleware and test modules; gorelease has not been rerun after preparation, so this is not a clean compatibility-check result.
- Tests and lint were not run locally as part of this release preparation; CI results should be reviewed before merge.
